### PR TITLE
🧹 Atom compliant entry documents

### DIFF
--- a/app/controllers/willow_sword/v2/file_sets_controller.rb
+++ b/app/controllers/willow_sword/v2/file_sets_controller.rb
@@ -7,7 +7,8 @@ module WillowSword
         @file_set = find_file_set
         render_file_set_not_found and return unless @file_set
 
-        render 'entry.hyku.xml.builder', formats: [:xml], status: :ok
+        xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
+        render 'entry.hyku.xml.builder', locals: { xw: xw }, formats: [:xml], status: :ok
       end
 
       def create
@@ -15,7 +16,8 @@ module WillowSword
         render_work_not_found and return unless @object
         @error = nil
         if perform_create
-          render 'entry.hyku.xml.builder', formats: [:xml], status: :created, location: v2_file_set_url(@file_set)
+          xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
+          render 'entry.hyku.xml.builder', locals: { xw: xw }, formats: [:xml], status: :created, location: v2_file_set_url(@file_set)
         else
           @error = WillowSword::Error.new("Error creating file set") unless @error.present?
           render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
@@ -27,11 +29,8 @@ module WillowSword
         render_file_set_not_found and return unless @file_set
 
         if perform_update
-          if WillowSword.config.xml_mapping_create == 'Hyku'
-            render 'entry.hyku.xml.builder', formats: [:xml], status: :ok
-          else
-            render 'update.xml.builder', formats: [:xml], status: :ok
-          end
+          xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
+          render 'entry.hyku.xml.builder', locals: { xw: xw }, formats: [:xml], status: :ok
         else
           @error = WillowSword::Error.new("Error updating file set") unless @error.present?
           render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
@@ -40,9 +39,6 @@ module WillowSword
 
       def extract_metadata(file_path)
         @attributes = {}
-
-        return super unless WillowSword.config.xml_mapping_create == 'Hyku'
-
         xw = WillowSword::V2::HykuCrosswalk.new(file_path, Hyrax.config.file_set_model.constantize)
         xw.map_xml
         @attributes = xw.metadata

--- a/app/controllers/willow_sword/v2/works_controller.rb
+++ b/app/controllers/willow_sword/v2/works_controller.rb
@@ -9,11 +9,9 @@ module WillowSword
         begin
           perform_create
           @file_set_ids = file_set_ids
-          if (WillowSword.config.xml_mapping_create == 'Hyku')
-            render 'entry.hyku.xml.builder', formats: [:xml], status: :created, location: v2_work_url(@object.id)
-          else
-            render 'create.xml.builder', formats: [:xml], status: :created, location: v2_work_url(@object.id)
-          end
+
+          xw = WillowSword::V2::HykuCrosswalk.new(nil, @object)
+          render 'entry.hyku.xml.builder', locals: { xw: xw }, status: :created, location: v2_work_url(@object.id)
         rescue StandardError => e
           @error = WillowSword::Error.new(e.message) unless @error.present?
           render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
@@ -21,19 +19,12 @@ module WillowSword
       end
 
       def show
-        # @collection_id = params[:collection_id]
         find_work_by_query
         render_not_found and return unless @object
         @file_set_ids = file_set_ids
 
-        if (WillowSword.config.xml_mapping_read == 'MODS')
-          @mods = assign_model_to_mods
-          render '/willow_sword/v2/works/show.mods.xml.builder', formats: [:xml], status: 200
-        elsif (WillowSword.config.xml_mapping_read == 'Hyku')
-          render '/willow_sword/v2/works/entry.hyku.xml.builder', formats: [:xml], status: 200
-        else
-          render '/willow_sword/v2/works/show.dc.xml.builder', formats: [:xml], status: 200
-        end
+        xw = WillowSword::V2::HykuCrosswalk.new(nil, @object)
+        render '/willow_sword/v2/works/entry.hyku.xml.builder', locals: { xw: xw }, status: 200
       end
 
       def update
@@ -43,11 +34,9 @@ module WillowSword
 
         begin
           perform_update
-          if (WillowSword.config.xml_mapping_create == 'Hyku')
-            render 'entry.hyku.xml.builder', formats: [:xml], status: :ok
-          else
-            render 'update.xml.builder', formats: [:xml], status: :ok
-          end
+
+          xw = WillowSword::V2::HykuCrosswalk.new(nil, @object)
+          render 'entry.hyku.xml.builder', locals: { xw: xw }, status: :ok
         rescue StandardError => e
           @error = WillowSword::Error.new(e.message) unless @error.present?
           render '/willow_sword/shared/error.xml.builder', formats: [:xml], status: @error.code
@@ -55,10 +44,6 @@ module WillowSword
       end
 
       def extract_metadata(file_path)
-        @attributes = nil
-
-        return super unless WillowSword.config.xml_mapping_create == 'Hyku'
-
         xw = WillowSword::V2::HykuCrosswalk.new(file_path, @work_klass)
         xw.map_xml
         @attributes = xw.metadata

--- a/app/views/willow_sword/v2/file_sets/entry.hyku.xml.builder
+++ b/app/views/willow_sword/v2/file_sets/entry.hyku.xml.builder
@@ -1,8 +1,8 @@
-xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
 xml.entry(xw.namespace_declarations) do
   xml.id @file_set.id
   xml.title @file_set.title.join(', ')
-  xml.content(src: v2_file_set_url(@file_set), type: 'text/html')
+  xml.content(src: Hyrax::Engine.routes.url_helpers.download_url(@file_set.id, host: request.host_with_port),
+              type: @file_set&.original_file&.mime_type || 'application/octet-stream')
   xml.link(rel: 'edit', href: v2_file_set_url(@file_set))
 
   xw.add_metadata_to_xml(xml)

--- a/app/views/willow_sword/v2/works/entry.hyku.xml.builder
+++ b/app/views/willow_sword/v2/works/entry.hyku.xml.builder
@@ -1,4 +1,3 @@
-xw = WillowSword::V2::HykuCrosswalk.new(nil, @object)
 xml.entry(xw.namespace_declarations) do
   xml.id @object.id
   xml.title @object.title.join(', ')


### PR DESCRIPTION
This commit will bring entry documents in much closer compliance with Atom specifications.  Also refactored the builder to pull some of that logic out into the controller instead as well as getting rid of the logic for V2 to check if it's Hyku because it will be Hyku.  We can extract this out later into a configuration so this gem isn't so Hyku focused, but for now this will do.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/379