### PR TITLE
🎁 Add child linking to atom response

### DIFF
--- a/app/views/willow_sword/v2/works/entry.hyku.xml.builder
+++ b/app/views/willow_sword/v2/works/entry.hyku.xml.builder
@@ -1,11 +1,16 @@
 xml.entry(xw.namespace_declarations) do
   xml.id @object.id
   xml.title @object.title.join(', ')
-  xml.content(src: v2_work_url(@object), type: 'text/html')
+  xml.content(src: Rails.application.routes.url_helpers.polymorphic_url(@object, host: request.host_with_port),
+              type: 'text/html')
   xml.link(rel: 'edit', href: v2_work_url(@object))
 
   @file_set_ids&.each do |file_set_id|
     xml.link(rel: 'edit-media', href: v2_file_set_url(file_set_id))
+  end
+
+  @child_work_ids&.each do |child_work_id|
+    xml.link(rel: 'related', href: v2_work_url(child_work_id))
   end
 
   xw.add_metadata_to_xml(xml)


### PR DESCRIPTION
If a work had a child work, it is now represented by `link[@rel="related"]`.  The `content[@rel="src"]` attribute now will point to the public URL instead of the SWORD URL.  Also, file sets should be present in all verb responses.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/380