### PR TITLE
🧹 Add error message for file sets

### DIFF
--- a/app/controllers/concerns/integrator/hyrax/file_sets_behavior.rb
+++ b/app/controllers/concerns/integrator/hyrax/file_sets_behavior.rb
@@ -53,7 +53,12 @@ module Integrator
               'file_set.save_acl' => { permissions_params: change_set.input_params["permissions"] }
             )
           .call(change_set).value_or { false }
-        @file_set = result if result
+        return @file_set = result if result
+
+        message = "Error updating file set: #{change_set.errors.full_messages.join(', ')}"
+        @error = WillowSword::Error.new(message, :unprocessable_entity)
+ 
+        raise @error
       end
 
       def coerce_valkyrie_params

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -21,6 +21,10 @@ Rails.application.config.to_prepare do
         def user_settable_attributes
           schema.keys.filter_map { |schema_key| schema_key.name unless schema_key.meta.empty? }
         end
+
+        def multiple_attributes
+          schema.keys.filter_map { |schema_key| schema_key.name if schema_key.meta['multiple'] == true }
+        end
       end
     end
 

--- a/lib/willow_sword/v2/hyku_crosswalk.rb
+++ b/lib/willow_sword/v2/hyku_crosswalk.rb
@@ -50,7 +50,7 @@ module WillowSword
       def system_terms
         %w(id internal_resource created_at
           updated_at new_record date_modified
-          date_uploaded depositor state).select { |term| terms_from_schema.include?(term) }
+          date_uploaded depositor state label).select { |term| terms_from_schema.include?(term) }
       end
 
       # @returns [Array<String>] a list of Dublin Core terms used in the object
@@ -105,7 +105,7 @@ module WillowSword
       end
 
       def singular
-        %w(rights) + visibility_terms
+        object_klass.user_settable_attributes.map(&:to_s) - object_klass.multiple_attributes.map(&:to_s) + visibility_terms
       end
 
       # DC Terms is a superset of Dublin Core, meaning all original DC elements


### PR DESCRIPTION
This commit will add a more robust way of handling and reporting errors for file set actions.  Also, moved the `label` property to the `h4csys` namespace.  It doesn't seem to want to change and I think we're okay with keeping it the same as the original filename.