### PR TITLE
Fix SWORD Api-key auth messages and HTTP 401/403 

### DIFF
--- a/app/controllers/concerns/willow_sword/authorize_request.rb
+++ b/app/controllers/concerns/willow_sword/authorize_request.rb
@@ -7,17 +7,25 @@ module WillowSword
       return true unless WillowSword.config.authorize_request
 
       api_key = @headers.fetch(:api_key, nil)
-      message =
-        if api_key.present?
-          @current_user = User.find_by(api_key: api_key)
-          'Not authorized. API key not found.' # not used if user is allowed
-        else
-          'Not authorized. API key not available.'
-        end
+      unless api_key.present?
+        @error = WillowSword::Error.new('Not authorized. API key not available.', :unauthenticated)
+        render 'willow_sword/shared/error', formats: [:xml], status: @error.code
+        return
+      end
+
+      @current_user = User.find_by(api_key: api_key)
+      if @current_user.blank?
+        @error = WillowSword::Error.new('Not authorized. API key not found.', :unauthenticated)
+        render 'willow_sword/shared/error', formats: [:xml], status: @error.code
+        return
+      end
 
       return true if allowed_access? && allowed_on_behalf?
 
-      @error = WillowSword::Error.new(message, :target_owner_unknown) unless @error.present?
+      @error ||= WillowSword::Error.new(
+        'Not authorized. You do not have access to this repository.',
+        :target_owner_unknown
+      )
       render 'willow_sword/shared/error', formats: [:xml], status: @error.code
     end
 

--- a/lib/willow_sword/error.rb
+++ b/lib/willow_sword/error.rb
@@ -32,6 +32,10 @@ module WillowSword
           iri: 'http://purl.org/net/sword/error/TargetOwnerUnknown',
           code: 403
         },
+        unauthenticated: {
+          iri: 'http://purl.org/net/sword/error/TargetOwnerUnknown',
+          code: 401
+        },
         mediation_not_allowed: {
           iri: 'http://purl.org/net/sword/error/MediationNotAllowed',
           code: 412

--- a/spec/lib/willow_sword/error_spec.rb
+++ b/spec/lib/willow_sword/error_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe WillowSword::Error do
       expect(error.errors).to include(:checksum_mismatch)
       expect(error.errors).to include(:bad_request)
       expect(error.errors).to include(:target_owner_unknown)
+      expect(error.errors).to include(:unauthenticated)
       expect(error.errors).to include(:mediation_not_allowed)
       expect(error.errors).to include(:method_not_allowed)
       expect(error.errors).to include(:max_upload_size_exceeded)
@@ -61,6 +62,14 @@ RSpec.describe WillowSword::Error do
       error = WillowSword::Error.new(msg, :target_owner_unknown)
       expect(error.iri).to eq('http://purl.org/net/sword/error/TargetOwnerUnknown')
       expect(error.code).to eq 403
+      expect(error.message).to eq msg
+    end
+
+    it "should return error of type unauthenticated" do
+      msg = 'unauthenticated'
+      error = WillowSword::Error.new(msg, :unauthenticated)
+      expect(error.iri).to eq('http://purl.org/net/sword/error/TargetOwnerUnknown')
+      expect(error.code).to eq 401
       expect(error.message).to eq msg
     end
 

--- a/spec/request/v2/service_document_spec.rb
+++ b/spec/request/v2/service_document_spec.rb
@@ -34,18 +34,40 @@ RSpec.describe 'SWORD Service Document', type: :request do
       end
 
       context 'with invalid API key' do
-        it 'returns 403 Forbidden' do
+        it 'returns 401 Unauthorized' do
           get '/sword/v2/service_document', headers: { 'Api-key' => 'invalid' }
 
-          expect(response).to have_http_status(:forbidden)
+          expect(response).to have_http_status(:unauthorized)
         end
       end
 
       context 'with no API key' do
-        it 'returns 403 Forbidden' do
+        it 'returns 401 Unauthorized' do
           get '/sword/v2/service_document'
 
+          expect(response).to have_http_status(:unauthorized)
+        end
+      end
+
+      # Mirrors Hyku multitenant behavior: global User row + api_key, but no repository
+      # roles for the current tenant (see authorize_request + allowed_access?).
+      context 'when Api-key matches a user who is not in the registered repository set' do
+        let(:denied_user) { create(:admin, email: 'no_repo_access@example.com', api_key: 'denied_key') }
+
+        before do
+          allow(User).to receive(:find_by).and_wrap_original do |method, *args, **kwargs|
+            kwargs[:api_key] == 'denied_key' ? denied_user : method.call(*args, **kwargs)
+          end
+          allow(denied_user).to receive(:in?).and_return(false)
+        end
+
+        it 'returns 403 Forbidden with a repository access message' do
+          get '/sword/v2/service_document', headers: { 'Api-key' => 'denied_key' }
+
           expect(response).to have_http_status(:forbidden)
+          expect(doc.at_xpath('//*[local-name()="summary"]').text).to include(
+            'do not have access to this repository'
+          )
         end
       end
     end


### PR DESCRIPTION
Improve SWORD API key auth responses

I wasn't able to reproduce the issue described in the ticket, however...

Return 401 when the key is missing or unknown; 403 when the key matches a
user who is not allowed for the repository. Replace the misleading
"API key not found" summary for the latter case. Update specs.

Issue: https://github.com/notch8/palni_palci_knapsack/issues/315

# BEFORE

response when forbidden user sent a request

```
<sword:error xmlns:sword="http://purl.org/net/sword/" xmlns:arxiv="http://arxiv.org/schemas/atom" xmlns="http://www.w3.org/2005/Atom" href="http://purl.org/net/sword/error/TargetOwnerUnknown">
  <author>
    <name>Sword v2 server</name>
  </author>
  <title>ERROR</title>
  <updated>2026-04-21T14:09:54Z</updated>
  <generator uri="https://example.org/sword-app/" version="0.1">
sword@example.org  </generator>
  <summary>Not authorized. API key not found.</summary>
  <sword:treatment>processing failed</sword:treatment>
</sword:error>
```

# AFTER

### when user found but is forbidden access

```
<sword:error xmlns:sword="http://purl.org/net/sword/" xmlns:arxiv="http://arxiv.org/schemas/atom" xmlns="http://www.w3.org/2005/Atom" href="http://purl.org/net/sword/error/TargetOwnerUnknown">
  <author>
    <name>Sword v2 server</name>
  </author>
  <title>ERROR</title>
  <updated>2026-04-21T14:10:28Z</updated>
  <generator uri="https://example.org/sword-app/" version="0.1">
sword@example.org  </generator>
  <summary>Not authorized. You do not have access to this repository.</summary>
  <sword:treatment>processing failed</sword:treatment>
</sword:error>
```


### when user isn't found 

```
<sword:error xmlns:sword="http://purl.org/net/sword/" xmlns:arxiv="http://arxiv.org/schemas/atom" xmlns="http://www.w3.org/2005/Atom" href="http://purl.org/net/sword/error/TargetOwnerUnknown">
  <author>
    <name>Sword v2 server</name>
  </author>
  <title>ERROR</title>
  <updated>2026-04-21T14:13:44Z</updated>
  <generator uri="https://example.org/sword-app/" version="0.1">
sword@example.org  </generator>
  <summary>Not authorized. API key not found.</summary>
  <sword:treatment>processing failed</sword:treatment>
</sword:error>
```