### PR TITLE
🐛 Fix legacy visibility responses

### DIFF
--- a/app/views/willow_sword/works/show.xml+hyku.builder
+++ b/app/views/willow_sword/works/show.xml+hyku.builder
@@ -29,6 +29,7 @@ xml.feed(xw.namespace_declarations) do
   xw.terms.each do |term|
     Array.wrap(@object.send(term)).each do |val|
       val = val.to_s
+      val = xw.handle_visibility(val) if term == 'visibility'
       next if val.blank?
 
       prefix = xw.prefix_lookup_for('h4cmeta')

--- a/lib/willow_sword/hyku_crosswalk.rb
+++ b/lib/willow_sword/hyku_crosswalk.rb
@@ -114,6 +114,18 @@ module WillowSword
          rights_notes rights_statement subject title resource_type).select { |term| work.respond_to?(term) }
     end
 
+    # Convert the visibility to read either 'embargo' or 'lease' when active.
+    def handle_visibility(value)
+      case value
+      when work.try(:embargo)&.active? && work.try(:visibility_during_embargo)
+        'embargo'
+      when work.try(:lease)&.active? && work.try(:visibility_during_lease)
+        'lease'
+      else
+        value
+      end
+    end
+
     private
 
     # Takes the work's schema and returns a hash of predicate mappings for terms
@@ -146,7 +158,7 @@ module WillowSword
     # @returns [Array<String>] a list of Hyrax based visibility terms
     def visibility_terms
       %w(visibility_during_embargo visibility_after_embargo embargo_release_date
-         visibility_during_lease visibility_after_lease lease_expiration_date)
+         visibility_during_lease visibility_after_lease lease_expiration_date visibility)
     end
   end
 end

--- a/spec/lib/willow_sword/hyku_crosswalk_spec.rb
+++ b/spec/lib/willow_sword/hyku_crosswalk_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 require 'willow_sword/hyku_crosswalk'
 require 'support/hyku_crosswalk_helper'
 
-RSpec.describe WillowSword::HykuCrosswalk do
+RSpec.describe WillowSword::HykuCrosswalk, type: :request do
   include HykuCrosswalkHelper
 
   subject(:xw) { described_class.new(work) }
@@ -71,6 +71,28 @@ RSpec.describe WillowSword::HykuCrosswalk do
         'access_right' => 'accessRights',
         'alternative_title' => 'alternative'
       )
+    end
+  end
+
+  describe '#handle_visibility' do
+    it 'returns the raw value when there is no active embargo or lease' do
+      allow(work).to receive(:embargo).and_return(nil)
+      allow(work).to receive(:lease).and_return(nil)
+      expect(xw.handle_visibility('open')).to eq 'open'
+    end
+
+    it 'translates to "embargo" when the work has an active embargo' do
+      allow(work).to receive(:embargo).and_return(double(active?: true))
+      allow(work).to receive(:lease).and_return(nil)
+      allow(work).to receive(:visibility_during_embargo).and_return('restricted')
+      expect(xw.handle_visibility('restricted')).to eq 'embargo'
+    end
+
+    it 'translates to "lease" when the work has an active lease' do
+      allow(work).to receive(:embargo).and_return(nil)
+      allow(work).to receive(:lease).and_return(double(active?: true))
+      allow(work).to receive(:visibility_during_lease).and_return('open')
+      expect(xw.handle_visibility('open')).to eq 'lease'
     end
   end
 end

--- a/spec/support/hyku_crosswalk_helper.rb
+++ b/spec/support/hyku_crosswalk_helper.rb
@@ -99,6 +99,7 @@ module HykuCrosswalkHelper
       video_embed: 'https://www.youtube.com/embed/Znf73dsFdC8',
       is_child: nil,
       split_from_pdf_id: nil,
+      visibility: '',
       visibility_during_embargo: '',
       visibility_after_embargo: '',
       embargo_release_date: '',


### PR DESCRIPTION
Using the legacy endpoint, if a work is under lease or embargo, the visibility returned in the response will be either lease or embargo instead of the actual underlying visibility such as restricted or public.

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/381