### PR TITLE
🎁 Better errors for sword routes

### DIFF
--- a/app/controllers/willow_sword/errors_controller.rb
+++ b/app/controllers/willow_sword/errors_controller.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'did_you_mean'
+
+module WillowSword
+  class ErrorsController < ApplicationController
+    skip_before_action :authorize_request
+
+    def not_found
+      message = "Route not found: #{request.method} #{request.path}"
+      message += ". Did you mean? #{request.script_name}#{suggested_path}" if suggested_path
+      @error = WillowSword::Error.new(message, :not_found)
+      render 'willow_sword/shared/error', formats: [:xml], status: @error.code
+    end
+
+    private
+
+    def suggested_path
+      @suggested_path ||= spell_check_suggestion || structural_suggestion
+    end
+
+    def spell_check_suggestion
+      DidYouMean::SpellChecker.new(dictionary: spell_check_dictionary).correct(request.path_info).first
+    end
+
+    def spell_check_dictionary
+      candidate_routes.map { |r| stripped_path(r) }.reject { |p| p.blank? || p == '/' }.uniq
+    end
+
+    def structural_suggestion
+      req_segs = path_segments(request.path_info)
+      return nil if req_segs.empty?
+
+      best = candidate_routes.filter_map do |route|
+        next unless route_accepts_verb?(route, request.method)
+        rt_segs = route_segments(route)
+        next if rt_segs.empty?
+
+        score = prefix_match_score(req_segs, rt_segs)
+        # Require every request segment to map to a route segment (exact or :placeholder).
+        next unless score == req_segs.size
+
+        [route, rt_segs.size]
+      end.min_by { |_, size| size }
+
+      best && '/' + route_segments(best.first).join('/')
+    end
+
+    def prefix_match_score(req_segs, rt_segs)
+      req_segs.zip(rt_segs).count do |req, rt|
+        rt && (rt == req || rt.start_with?(':'))
+      end
+    end
+
+    def route_accepts_verb?(route, method)
+      verb = route.verb
+      return true if verb.blank?
+      verb.is_a?(Regexp) ? verb.match?(method) : verb.to_s.casecmp?(method)
+    end
+
+    def candidate_routes
+      WillowSword::Engine.routes.routes.reject { |r| r.path.spec.to_s.include?('*') }
+    end
+
+    def stripped_path(route)
+      route.path.spec.to_s.gsub('(.:format)', '').gsub(%r{/:[^/]+}, '')
+    end
+
+    def route_segments(route)
+      path_segments(route.path.spec.to_s.gsub('(.:format)', ''))
+    end
+
+    def path_segments(path)
+      path.split('/').reject(&:empty?)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,5 +27,7 @@ WillowSword::Engine.routes.draw do
         resources :file_sets, only: [:create]
       end
     end
+
+    match '*unmatched', to: 'errors#not_found', via: :all
   end
 end

--- a/lib/willow_sword/error.rb
+++ b/lib/willow_sword/error.rb
@@ -48,6 +48,10 @@ module WillowSword
           iri: 'http://purl.org/net/sword/error/MaxUploadSizeExceeded',
           code: 413
         },
+        not_found: {
+          iri: 'http://purl.org/net/sword/error/ErrorBadRequest',
+          code: 404
+        },
         default: {
           iri: 'http://purl.org/net/sword/error/ErrorBadRequest',
           code: 400

--- a/spec/lib/willow_sword/error_spec.rb
+++ b/spec/lib/willow_sword/error_spec.rb
@@ -14,7 +14,16 @@ RSpec.describe WillowSword::Error do
       expect(error.errors).to include(:mediation_not_allowed)
       expect(error.errors).to include(:method_not_allowed)
       expect(error.errors).to include(:max_upload_size_exceeded)
+      expect(error.errors).to include(:not_found)
       expect(error.errors).to include(:default)
+    end
+
+    it "should return error of type not_found" do
+      msg = 'not found'
+      error = WillowSword::Error.new(msg, :not_found)
+      expect(error.iri).to eq('http://purl.org/net/sword/error/ErrorBadRequest')
+      expect(error.code).to eq 404
+      expect(error.message).to eq msg
     end
 
     it "should default to bad_request when no value" do

--- a/spec/request/routing_errors_spec.rb
+++ b/spec/request/routing_errors_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'SWORD routing errors', type: :request do
+  let(:atom_ns) { { 'atom' => 'http://www.w3.org/2005/Atom' } }
+  let(:sword_ns) { { 'sword' => 'http://purl.org/net/sword/' } }
+
+  def expect_xml_sword_error(status:)
+    expect(response).to have_http_status(status)
+    expect(response.media_type).to eq('application/xml')
+
+    doc = Nokogiri::XML(response.body)
+    expect(doc.errors).to be_empty
+    expect(doc.root.name).to eq('error')
+    expect(doc.root.namespace.href).to eq('http://purl.org/net/sword/')
+    doc
+  end
+
+  describe 'GET /sword/service_documents (typo for /sword/service_document)' do
+    it 'returns 404 XML and suggests the correct path via DidYouMean' do
+      get '/sword/service_documents'
+
+      doc = expect_xml_sword_error(status: :not_found)
+      summary = doc.root.xpath('atom:summary', atom_ns).text
+      expect(summary).to include('Route not found: GET /sword/service_documents')
+      expect(summary).to include('Did you mean? /sword/service_document')
+    end
+  end
+
+  describe 'POST /sword/collections/:id (missing /works suffix)' do
+    it 'returns 404 XML and suggests /sword/collections/:collection_id/works via structural match' do
+      post '/sword/collections/656e99ca-c20c-47f1-9752-31f84fbf87ee'
+
+      doc = expect_xml_sword_error(status: :not_found)
+      summary = doc.root.xpath('atom:summary', atom_ns).text
+      expect(summary).to include('Route not found: POST /sword/collections/656e99ca-c20c-47f1-9752-31f84fbf87ee')
+      expect(summary).to include('Did you mean? /sword/collections/:collection_id/works')
+    end
+  end
+
+  describe 'POST /sword/v2/collections/:id (missing /works suffix)' do
+    it 'returns 404 XML and suggests /sword/v2/collections/:collection_id/works' do
+      post '/sword/v2/collections/656e99ca-c20c-47f1-9752-31f84fbf87ee'
+
+      doc = expect_xml_sword_error(status: :not_found)
+      summary = doc.root.xpath('atom:summary', atom_ns).text
+      expect(summary).to include('Did you mean? /sword/v2/collections/:collection_id/works')
+    end
+  end
+
+  describe 'GET /sword/v2/totally-bogus' do
+    it 'returns 404 XML' do
+      get '/sword/v2/totally-bogus'
+
+      expect_xml_sword_error(status: :not_found)
+    end
+  end
+
+  describe 'when the path is so far off DidYouMean has no match' do
+    it 'returns 404 XML and omits the suggestion clause' do
+      get '/sword/zzzzzzzzzzzzzzzzzzzz'
+
+      doc = expect_xml_sword_error(status: :not_found)
+      summary = doc.root.xpath('atom:summary', atom_ns).text
+      expect(summary).not_to include('Did you mean')
+    end
+  end
+end


### PR DESCRIPTION
This commit will add better error atom responses when routing errors occur.

Command:
```sh
curl -sk -H 'Api-key: testing' https://dev-hyku.localhost.direct/sword/service_documents
```
Response:
```xml
<sword:error xmlns:sword="http://purl.org/net/sword/" xmlns:arxiv="http://arxiv.org/schemas/atom" xmlns="http://www.w3.org/2005/Atom" href="http://purl.org/net/sword/error/ErrorBadRequest">
  <author>
    <name>Sword v2 server</name>
  </author>
  <title>ERROR</title>
  <updated>2026-05-04T21:59:59Z</updated>
  <generator uri="https://example.org/sword-app/" version="0.1">
sword@example.org  </generator>
  <summary>Route not found: GET /sword/service_documents. Did you mean? /sword/service_document</summary>
  <sword:treatment>processing failed</sword:treatment>
</sword:error>
```
Command:
```sh
curl -sk -X POST -H 'Api-key: testing' https://dev-hyku.localhost.direct/sword/v2/collections/656e99ca-c20c-47f1-9752-31f84fbf87ee
```
Response:
```xml
<sword:error xmlns:sword="http://purl.org/net/sword/" xmlns:arxiv="http://arxiv.org/schemas/atom" xmlns="http://www.w3.org/2005/Atom" href="http://purl.org/net/sword/error/ErrorBadRequest">
  <author>
    <name>Sword v2 server</name>
  </author>
  <title>ERROR</title>
  <updated>2026-05-04T22:00:21Z</updated>
  <generator uri="https://example.org/sword-app/" version="0.1">
sword@example.org  </generator>
  <summary>Route not found: POST /sword/v2/collections/656e99ca-c20c-47f1-9752-31f84fbf87ee. Did you mean? /sword/v2/collections/:collection_id/works</summary>
  <sword:treatment>processing failed</sword:treatment>
</sword:error>
```
Command:
```sh
curl -sk -H 'Api-key: testing' https://dev-hyku.localhost.direct/sword/zzzzzzzzzzzzzzzzzzzz
```
Response:
```xml
<sword:error xmlns:sword="http://purl.org/net/sword/" xmlns:arxiv="http://arxiv.org/schemas/atom" xmlns="http://www.w3.org/2005/Atom" href="http://purl.org/net/sword/error/ErrorBadRequest">
  <author>
    <name>Sword v2 server</name>
  </author>
  <title>ERROR</title>
  <updated>2026-05-04T22:03:09Z</updated>
  <generator uri="https://example.org/sword-app/" version="0.1">
sword@example.org  </generator>
  <summary>Route not found: GET /sword/zzzzzzzzzzzzzzzzzzzz</summary>
  <sword:treatment>processing failed</sword:treatment>
</sword:error>
```

Ref:
- https://github.com/notch8/palni_palci_knapsack/issues/639