### PR TITLE
Add chunked upload support to legacy SWORD routes

### DIFF
--- a/app/controllers/concerns/willow_sword/chunked_upload_handler.rb
+++ b/app/controllers/concerns/willow_sword/chunked_upload_handler.rb
@@ -1,0 +1,289 @@
+require 'fileutils'
+require 'securerandom'
+require 'json'
+require 'digest'
+
+module WillowSword
+  module ChunkedUploadHandler
+    extend ActiveSupport::Concern
+
+    def append_chunk(upload_id:, body_stream:, content_range:)
+      range = parse_content_range(content_range)
+      payload_path = File.join(upload_path(upload_id), 'payload')
+
+      with_manifest_lock(upload_id) do
+        manifest = read_manifest(upload_id)
+        raise WillowSword::SwordError.new(WillowSword::Error.new("Upload not found", :upload_not_found)) unless manifest
+
+        validate_chunk!(manifest, range)
+
+        expected_chunk_size = range[:range_end] - range[:range_start] + 1
+        prior_size = Integer(manifest[:bytes_received] || 0)
+        on_disk = File.file?(payload_path) ? File.size(payload_path) : 0
+        if on_disk != prior_size
+          raise WillowSword::SwordError.new(WillowSword::Error.new(
+            "Payload file is inconsistent with manifest (expected #{prior_size} bytes before this chunk, file has #{on_disk} on disk)",
+            :bad_request
+          ))
+        end
+
+        copied_bytes = File.open(payload_path, 'ab') do |f|
+          n = IO.copy_stream(body_stream, f)
+          f.fsync
+          n
+        end
+
+        if copied_bytes != expected_chunk_size
+          if prior_size > 0
+            File.truncate(payload_path, prior_size)
+          else
+            FileUtils.rm_f(payload_path)
+          end
+          raise WillowSword::SwordError.new(WillowSword::Error.new(
+            "Request body size (#{copied_bytes} bytes) does not match Content-Range (expected #{expected_chunk_size} bytes)",
+            :bad_request
+          ))
+        end
+
+        manifest[:bytes_received] = range[:range_end] + 1
+        complete = manifest[:bytes_received] >= Integer(manifest[:total_size] || 0)
+
+        if complete
+          manifest[:status] = 'complete'
+          if manifest[:md5].present?
+            actual_md5 = Digest::MD5.file(payload_path).hexdigest
+            unless actual_md5 == manifest[:md5]
+              manifest[:status] = 'checksum_failed'
+              write_manifest(upload_id, manifest)
+              raise WillowSword::SwordError.new(WillowSword::Error.new("Checksum mismatch for assembled file", :checksum_mismatch))
+            end
+          end
+        end
+
+        write_manifest(upload_id, manifest)
+        { bytes_received: manifest[:bytes_received], complete: complete }
+      end
+    end
+
+    def upload_status(upload_id)
+      manifest = read_manifest(upload_id)
+      return nil unless manifest
+      manifest
+    end
+
+    def upload_complete?(upload_id)
+      manifest = read_manifest(upload_id)
+      manifest.present? && manifest[:status] == 'complete'
+    end
+
+    def upload_file_path(upload_id)
+      File.join(upload_path(upload_id), 'payload')
+    end
+
+    def upload_filename(upload_id)
+      manifest = read_manifest(upload_id)
+      manifest&.dig(:filename)
+    end
+
+    def initiate_staging(work_id:, collection_id: nil, metadata_path: nil, filename: nil, md5: nil, user_id: nil)
+      staging_id = SecureRandom.uuid
+      staging_dir = upload_path(staging_id)
+      FileUtils.mkdir_p(staging_dir)
+
+      if metadata_path.present? && File.exist?(metadata_path)
+        FileUtils.cp(metadata_path, File.join(staging_dir, 'metadata.xml'))
+      end
+
+      manifest = {
+        work_id: work_id,
+        collection_id: collection_id,
+        filename: filename,
+        total_size: nil,
+        md5: md5,
+        user_id: user_id,
+        created_at: Time.current.iso8601,
+        bytes_received: 0,
+        status: 'awaiting_upload'
+      }
+
+      write_manifest(staging_id, manifest)
+      staging_id
+    end
+
+    def activate_staging(upload_id:, total_size:)
+      with_manifest_lock(upload_id) do
+        manifest = read_manifest(upload_id)
+        raise WillowSword::SwordError.new(WillowSword::Error.new("Upload not found", :upload_not_found)) unless manifest
+
+        max = WillowSword.setup.max_total_upload_size
+        if total_size > max
+          raise WillowSword::SwordError.new(WillowSword::Error.new(
+            "Total size #{total_size} exceeds maximum #{max}", :max_upload_size_exceeded
+          ))
+        end
+
+        manifest[:total_size] = total_size
+        manifest[:status] = 'in_progress'
+        write_manifest(upload_id, manifest)
+      end
+    end
+
+    def staging_entry?(upload_id)
+      read_manifest(upload_id).present?
+    end
+
+    def staging_metadata_path(upload_id)
+      path = File.join(upload_path(upload_id), 'metadata.xml')
+      File.exist?(path) ? path : nil
+    end
+
+    def cancel_upload(upload_id)
+      dir = upload_path(upload_id)
+      FileUtils.rm_rf(dir) if File.directory?(dir)
+    end
+
+    def cleanup_stale_uploads
+      base = chunked_upload_base_path
+      return unless File.directory?(base)
+
+      expiry = WillowSword.setup.chunked_upload_expiry
+
+      Dir.glob(File.join(base, '*')).each do |dir|
+        next unless File.directory?(dir)
+        manifest_path = File.join(dir, 'manifest.json')
+        next unless File.exist?(manifest_path)
+
+        begin
+          manifest = JSON.parse(File.read(manifest_path), symbolize_names: true)
+          created_at = Time.parse(manifest[:created_at])
+          if Time.current - created_at > expiry
+            FileUtils.rm_rf(dir)
+          end
+        rescue StandardError
+          # If manifest is corrupt, clean up if dir is old enough
+          if File.mtime(dir) < Time.current - expiry
+            FileUtils.rm_rf(dir)
+          end
+        end
+      end
+    end
+
+    def parse_content_range(header)
+      # Format: "bytes START-END/TOTAL"
+      match = header&.match(/\Abytes (\d+)-(\d+)\/(\d+)\z/)
+      unless match
+        raise WillowSword::SwordError.new(WillowSword::Error.new("Invalid Content-Range header format", :bad_request))
+      end
+
+      {
+        range_start: match[1].to_i,
+        range_end: match[2].to_i,
+        total: match[3].to_i
+      }
+    end
+
+    private
+
+    def validate_chunk!(manifest, range)
+      # JSON may return integers as string in some runtimes; coerce for comparisons
+      total_size = Integer(manifest[:total_size] || 0)
+      bytes_received = Integer(manifest[:bytes_received] || 0)
+
+      if range[:total] != total_size
+        raise WillowSword::SwordError.new(WillowSword::Error.new(
+          "Content-Range total (#{range[:total]}) does not match declared upload size (#{total_size})",
+          :bad_request
+        ))
+      end
+
+      if range[:range_start] > range[:range_end]
+        raise WillowSword::SwordError.new(WillowSword::Error.new(
+          "Content-Range has start (#{range[:range_start]}) after end (#{range[:range_end]})",
+          :bad_request
+        ))
+      end
+
+      if range[:range_start].negative? || range[:range_end] >= total_size
+        raise WillowSword::SwordError.new(WillowSword::Error.new(
+          "Content-Range bytes must be within 0..#{[total_size - 1, 0].max} for a #{total_size}-byte upload",
+          :bad_request
+        ))
+      end
+
+      if range[:range_start] != bytes_received
+        raise WillowSword::SwordError.new(WillowSword::Error.new(
+          "Expected chunk starting at byte #{bytes_received}, got #{range[:range_start]}",
+          :chunk_sequence_error
+        ))
+      end
+
+      chunk_size = range[:range_end] - range[:range_start] + 1
+      max = WillowSword.setup.max_chunk_size
+      if chunk_size > max
+        raise WillowSword::SwordError.new(WillowSword::Error.new(
+          "Chunk size #{chunk_size} exceeds maximum #{max}",
+          :max_upload_size_exceeded
+        ))
+      end
+
+      unless %w[in_progress awaiting_upload].include?(manifest[:status])
+        raise WillowSword::SwordError.new(WillowSword::Error.new(
+          "Upload is not in progress (status: #{manifest[:status]})",
+          :bad_request
+        ))
+      end
+    end
+
+    def upload_path(upload_id)
+      File.join(chunked_upload_base_path, upload_id)
+    end
+
+    def chunked_upload_base_path
+      WillowSword.setup.chunked_upload_path || 'tmp/network_files/willow_sword'
+    end
+
+    def manifest_path(upload_id)
+      File.join(upload_path(upload_id), 'manifest.json')
+    end
+
+    def read_manifest(upload_id)
+      # No lock needed: write_manifest uses atomic temp-file + rename,
+      # so readers always see a complete JSON file.
+      path = manifest_path(upload_id)
+      return nil unless File.exist?(path)
+      JSON.parse(File.read(path), symbolize_names: true)
+    end
+
+    def write_manifest(upload_id, manifest)
+      path = manifest_path(upload_id)
+      tmp = File.join(upload_path(upload_id), ".manifest.#{SecureRandom.hex(4)}.tmp")
+
+      begin
+        File.open(tmp, 'w') do |f|
+          f.write(JSON.generate(manifest))
+          f.flush
+          f.fsync
+        end
+        File.rename(tmp, path)
+      rescue StandardError
+        FileUtils.rm_f(tmp)
+        raise
+      end
+    end
+
+    def with_manifest_lock(upload_id)
+      dir = upload_path(upload_id)
+      unless File.directory?(dir)
+        raise WillowSword::SwordError.new(WillowSword::Error.new("Upload not found", :upload_not_found))
+      end
+
+      lock_path = File.join(dir, '.lock')
+      # Open read-write: LOCK_EX on a read-only fd can fail (EBADF) on NFS/EFS-backed mounts
+      # (e.g. Hyku tmp/network_files) even though the same call works on local ext4.
+      File.open(lock_path, File::CREAT | File::RDWR, 0o644) do |f|
+        f.flock(File::LOCK_EX)
+        yield
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/willow_sword/fetch_headers.rb
+++ b/app/controllers/concerns/willow_sword/fetch_headers.rb
@@ -17,6 +17,7 @@ module WillowSword
       fetch_slug
       fetch_hyrax_work_model
       fetch_api_key
+      fetch_content_range
     end
 
     def fetch_content_type
@@ -63,6 +64,10 @@ module WillowSword
 
     def fetch_api_key
       @headers[:api_key] = request.headers.fetch('Api-key', nil)
+    end
+
+    def fetch_content_range
+      @headers[:content_range] = request.headers.fetch('Content-Range', nil)
     end
 
     # Looks for the lazy migration convention if it exists

--- a/app/controllers/concerns/willow_sword/process_request.rb
+++ b/app/controllers/concerns/willow_sword/process_request.rb
@@ -10,6 +10,7 @@ module WillowSword
     def validate_and_save_request
       # Choose based on content type
       return false unless validate_target_user
+
       case request.content_type
       when /\Amultipart\/form-data/
         # multipart deposit

--- a/app/controllers/willow_sword/file_sets_controller.rb
+++ b/app/controllers/willow_sword/file_sets_controller.rb
@@ -5,44 +5,64 @@ module WillowSword
     before_action :set_file_set_klass
     attr_reader :file_set, :object
     include WillowSword::ProcessRequest
+    include WillowSword::ChunkedUploadHandler
     include WillowSword::Integrator::WorksBehavior
     include WillowSword::Integrator::FileSetsBehavior
 
+    rescue_from WillowSword::SwordError, with: :handle_sword_error
+
     def show
-      @file_set = find_file_set
-      render_file_set_not_found and return unless @file_set
+      # Check for staging entry first
+      @staging_manifest = upload_status(params[:id])
+      if @staging_manifest
+        @staging_id = params[:id]
+        @staging_href = collection_work_file_set_url(params[:collection_id], params[:work_id], @staging_id)
+        render 'willow_sword/shared/staging_status', formats: [:xml], status: :ok
+      else
+        @file_set = find_file_set
+        render_file_set_not_found and return unless @file_set
+      end
     end
 
     def create
       # Find work
       find_work_by_query(params[:work_id])
       render_work_not_found and return unless @object
-      @error = nil
-      if perform_create
-        # @collection_id = params[:collection_id]
-        render 'create', formats: [:xml], status: :created,
-          location: collection_work_file_set_url(params[:collection_id], @object, @file_set)
+
+      if in_progress_deposit?
+        perform_staging_initiation
       else
-        @error = WillowSword::Error.new("Error creating file set") unless @error.present?
-        render 'willow_sword/shared/error', formats: [:xml], status: @error.code
+        @error = nil
+        if perform_create
+          render 'create', formats: [:xml], status: :created,
+            location: collection_work_file_set_url(params[:collection_id], @object, @file_set)
+        else
+          @error = WillowSword::Error.new("Error creating file set") unless @error.present?
+          render 'willow_sword/shared/error', formats: [:xml], status: @error.code
+        end
       end
     end
 
     def update
-      # Find work
-      find_work_by_query(params[:work_id])
-      render_work_not_found and return unless @object
-      # Find file set
-      @file_set = find_file_set
-      render_file_set_not_found and return unless @file_set
-      @error = nil
-      if perform_update
-        render 'update', formats: [:xml], status: :no_content
+      # Check for staging entry first
+      @staging_manifest = upload_status(params[:id])
+      if @staging_manifest
+        perform_chunked_update
       else
-        @error = WillowSword::Error.new("Error updating file set") unless @error.present?
-        render 'willow_sword/shared/error', formats: [:xml], status: @error.code
+        # Find work
+        find_work_by_query(params[:work_id])
+        render_work_not_found and return unless @object
+        # Find file set
+        @file_set = find_file_set
+        render_file_set_not_found and return unless @file_set
+        @error = nil
+        if perform_update
+          render 'update', formats: [:xml], status: :no_content
+        else
+          @error = WillowSword::Error.new("Error updating file set") unless @error.present?
+          render 'willow_sword/shared/error', formats: [:xml], status: @error.code
+        end
       end
-
     end
 
     private
@@ -68,6 +88,133 @@ module WillowSword
         return false unless parse_metadata(@metadata_file, false)
         update_file_set
         true
+      end
+
+      # --- Chunked upload helpers ---
+
+      def in_progress_deposit?
+        @headers[:in_progress]&.downcase == 'true'
+      end
+
+      def perform_staging_initiation
+        metadata_file = save_staging_metadata
+
+        begin
+          @staging_id = initiate_staging(
+            work_id: params[:work_id],
+            collection_id: params[:collection_id],
+            metadata_path: metadata_file,
+            filename: @headers[:filename],
+            md5: @headers[:md5hash],
+            user_id: @current_user&.id
+          )
+        ensure
+          FileUtils.rm_rf(File.dirname(metadata_file)) if metadata_file
+        end
+
+        @staging_manifest = upload_status(@staging_id)
+        @staging_href = collection_work_file_set_url(params[:collection_id], params[:work_id], @staging_id)
+
+        render 'willow_sword/shared/staging_status', formats: [:xml], status: :created
+      end
+
+      def save_staging_metadata
+        request.body.rewind
+        body = request.body.read
+        return nil if body.blank?
+
+        dir = File.join('tmp/data', SecureRandom.uuid)
+        FileUtils.mkdir_p(dir)
+        path = File.join(dir, 'metadata.xml')
+        File.open(path, 'wb') { |f| f.write(body) }
+        path
+      end
+
+      def perform_chunked_update
+        content_range = @headers[:content_range]
+        unless content_range.present?
+          @error = WillowSword::Error.new("Content-Range header is required for chunked uploads", :bad_request)
+          render 'willow_sword/shared/error', formats: [:xml], status: @error.code
+          return
+        end
+
+        staging_id = params[:id]
+
+        # Activate upload tracking on first chunk
+        if @staging_manifest[:status] == 'awaiting_upload'
+          range = parse_content_range(content_range)
+          activate_staging(upload_id: staging_id, total_size: range[:total])
+        end
+
+        result = append_chunk(
+          upload_id: staging_id,
+          body_stream: request.body,
+          content_range: content_range
+        )
+
+        if result[:complete] && !in_progress_deposit?
+          finalize_staged_upload(staging_id)
+        else
+          @staging_id = staging_id
+          @staging_manifest = upload_status(staging_id)
+          @staging_href = collection_work_file_set_url(
+            @staging_manifest[:collection_id] || params[:collection_id],
+            @staging_manifest[:work_id] || params[:work_id],
+            staging_id
+          )
+          render 'willow_sword/shared/staging_status', formats: [:xml], status: :ok
+        end
+      end
+
+      def finalize_staged_upload(staging_id)
+        manifest = upload_status(staging_id)
+
+        # Find the parent work
+        find_work_by_query(manifest[:work_id])
+        unless @object
+          @error = WillowSword::Error.new("Work #{manifest[:work_id]} not found", :bad_request)
+          render 'willow_sword/shared/error', formats: [:xml], status: @error.code
+          return
+        end
+
+        # Set up files from the assembled payload
+        payload_path = upload_file_path(staging_id)
+        filename = upload_filename(staging_id) || 'payload'
+
+        finalize_dir = File.join('tmp/data', SecureRandom.uuid, 'contents')
+        FileUtils.mkdir_p(finalize_dir)
+
+        begin
+          dest = File.join(finalize_dir, filename)
+          FileUtils.cp(payload_path, dest)
+          @files = [dest]
+
+          # Parse staged metadata
+          metadata_path = staging_metadata_path(staging_id)
+          if metadata_path
+            parse_metadata(metadata_path, false)
+          else
+            @attributes = {}
+          end
+
+          # Create the Hyrax file set (same flow as perform_create)
+          upload_files unless @files.blank?
+          create_file_set
+
+          collection_id = manifest[:collection_id] || params[:collection_id]
+          render 'create', formats: [:xml], status: :created,
+            location: collection_work_file_set_url(collection_id, @object, @file_set)
+        ensure
+          cancel_upload(staging_id)
+          FileUtils.rm_rf(File.dirname(finalize_dir))
+        end
+      end
+
+      # --- Error helpers ---
+
+      def handle_sword_error(exception)
+        @error = exception.sword_error
+        render 'willow_sword/shared/error', formats: [:xml], status: @error.code
       end
 
       def render_file_set_not_found

--- a/app/controllers/willow_sword/v2/file_sets_controller.rb
+++ b/app/controllers/willow_sword/v2/file_sets_controller.rb
@@ -3,31 +3,164 @@
 module WillowSword
   module V2
     class FileSetsController < WillowSword::FileSetsController
+      include WillowSword::ChunkedUploadHandler
       include WillowSword::HandleError
 
       before_action :find_object_or_render_not_found, only: [:create, :show, :update]
       before_action :authorize_action, only: [:create, :show, :update]
 
       def create
-        perform_create
+        if in_progress_deposit?
+          perform_staging_initiation
+        else
+          perform_create
 
-        xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
-        render 'entry', formats: [:xml], variants: [:hyku], locals: { xw: xw }, status: :created
+          xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
+          render 'entry', formats: [:xml], variants: [:hyku], locals: { xw: xw }, status: :created
+        end
       end
 
       def show
-        xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
-        render 'entry', formats: [:xml], variants: [:hyku], locals: { xw: xw }, status: :ok
+        if @staging_manifest
+          render 'willow_sword/shared/staging_status', formats: [:xml], status: :ok
+        else
+          xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
+          render 'entry', formats: [:xml], variants: [:hyku], locals: { xw: xw }, status: :ok
+        end
       end
 
       def update
-        perform_update
+        if @staging_manifest
+          perform_chunked_update
+        else
+          perform_update
 
-        xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
-        render 'entry', formats: [:xml], variants: [:hyku], locals: { xw: xw }, status: :ok
+          xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
+          render 'entry', formats: [:xml], variants: [:hyku], locals: { xw: xw }, status: :ok
+        end
       end
 
       private
+
+      def in_progress_deposit?
+        @headers[:in_progress]&.downcase == 'true'
+      end
+
+      # --- Staging initiation (POST with In-Progress: true) ---
+
+      def perform_staging_initiation
+        metadata_file = save_staging_metadata
+
+        begin
+          @staging_id = initiate_staging(
+            work_id: params[:work_id],
+            metadata_path: metadata_file,
+            filename: @headers[:filename],
+            md5: @headers[:md5hash],
+            user_id: @current_user&.id
+          )
+        ensure
+          # Clean up the temp metadata file; initiate_staging already copied it into staging dir
+          FileUtils.rm_rf(File.dirname(metadata_file)) if metadata_file
+        end
+
+        @staging_manifest = upload_status(@staging_id)
+        @staging_href = v2_file_set_url(@staging_id)
+
+        render 'willow_sword/shared/staging_status', formats: [:xml], status: :created
+      end
+
+      def save_staging_metadata
+        request.body.rewind
+        body = request.body.read
+        return nil if body.blank?
+
+        dir = File.join('tmp/data', SecureRandom.uuid)
+        FileUtils.mkdir_p(dir)
+        path = File.join(dir, 'metadata.xml')
+        File.open(path, 'wb') { |f| f.write(body) }
+        path
+      end
+
+      # --- Chunked upload (PUT with Content-Range) ---
+
+      def perform_chunked_update
+        content_range = @headers[:content_range]
+        unless content_range.present?
+          return render_sword_error("Content-Range header is required for chunked uploads", :bad_request)
+        end
+
+        staging_id = params[:id]
+
+        # Activate upload tracking on first chunk
+        if @staging_manifest[:status] == 'awaiting_upload'
+          range = parse_content_range(content_range)
+          activate_staging(upload_id: staging_id, total_size: range[:total])
+        end
+
+        result = append_chunk(
+          upload_id: staging_id,
+          body_stream: request.body,
+          content_range: content_range
+        )
+
+        if result[:complete] && !in_progress_deposit?
+          finalize_staged_upload(staging_id)
+        else
+          @staging_id = staging_id
+          @staging_manifest = upload_status(staging_id)
+          @staging_href = v2_file_set_url(staging_id)
+          render 'willow_sword/shared/staging_status', formats: [:xml], status: :ok
+        end
+      end
+
+      def finalize_staged_upload(staging_id)
+        manifest = upload_status(staging_id)
+
+        # Find the parent work
+        find_work_by_query(manifest[:work_id])
+        unless @object
+          return render_sword_error("Work #{manifest[:work_id]} not found", :bad_request)
+        end
+
+        # Set up files from the assembled payload (cp, not mv, so staging is intact on failure)
+        payload_path = upload_file_path(staging_id)
+        filename = upload_filename(staging_id) || 'payload'
+
+        finalize_dir = File.join('tmp/data', SecureRandom.uuid, 'contents')
+        FileUtils.mkdir_p(finalize_dir)
+
+        begin
+          dest = File.join(finalize_dir, filename)
+          FileUtils.cp(payload_path, dest)
+          @files = [dest]
+
+          # Parse staged metadata
+          metadata_path = staging_metadata_path(staging_id)
+          if metadata_path
+            parse_metadata(metadata_path, false)
+          else
+            @attributes = {}
+          end
+
+          # Create the Hyrax file set (same flow as perform_create)
+          upload_files unless @files.blank?
+          create_file_set
+
+          xw = WillowSword::V2::HykuCrosswalk.new(nil, @file_set)
+          render 'entry', formats: [:xml], variants: [:hyku], locals: { xw: xw }, status: :created
+        ensure
+          cancel_upload(staging_id)
+          FileUtils.rm_rf(File.dirname(finalize_dir))
+        end
+      end
+
+      # --- Shared helpers ---
+
+      def render_sword_error(message, type)
+        @error = WillowSword::Error.new(message, type)
+        render 'willow_sword/shared/error', formats: [:xml], status: @error.code
+      end
 
       def extract_metadata(file_path)
         xw = WillowSword::V2::HykuCrosswalk.new(file_path, Hyrax.config.file_set_model.constantize)
@@ -40,22 +173,48 @@ module WillowSword
         case action_name
         when 'create'
           find_work_by_query(params[:work_id])
-          render_work_not_found if @object.nil?
+          render_work_not_found and return if @object.nil?
         when 'show', 'update'
-          @file_set = find_file_set
-          render_file_set_not_found if @file_set.nil?
+          # Check for staging entry first, then fall back to real Hyrax file set
+          @staging_manifest = upload_status(params[:id])
+          if @staging_manifest
+            @staging_id = params[:id]
+            @staging_href = v2_file_set_url(@staging_id)
+          else
+            @file_set = find_file_set
+            render_file_set_not_found and return if @file_set.nil?
+          end
         end
       end
 
       def authorize_action
+        return if performed?
+
         case action_name
         when 'create'
           authorize! :create, @object
         when 'show'
-          authorize! :read, @file_set
+          if @staging_manifest
+            validate_staging_owner!
+          else
+            authorize! :read, @file_set
+          end
         when 'update'
-          authorize! :edit, @file_set
+          if @staging_manifest
+            validate_staging_owner!
+          else
+            authorize! :edit, @file_set
+          end
         end
+      end
+
+      def validate_staging_owner!
+        return true unless @current_user
+        return true if @staging_manifest[:user_id].nil?
+        return true if @staging_manifest[:user_id] == @current_user.id
+
+        render_sword_error("Not authorized for this upload", :target_owner_unknown)
+        false
       end
     end
   end

--- a/app/jobs/willow_sword/cleanup_stale_uploads_job.rb
+++ b/app/jobs/willow_sword/cleanup_stale_uploads_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module WillowSword
+  class CleanupStaleUploadsJob < ApplicationJob
+    queue_as :default
+
+    def perform
+      handler = Object.new.extend(WillowSword::ChunkedUploadHandler)
+      handler.cleanup_stale_uploads
+    end
+  end
+end

--- a/app/views/willow_sword/shared/staging_status.xml.builder
+++ b/app/views/willow_sword/shared/staging_status.xml.builder
@@ -1,0 +1,12 @@
+xml.entry(
+  'xmlns:sword' => 'http://purl.org/net/sword/',
+  'xmlns:atom' => 'http://www.w3.org/2005/Atom'
+) do
+  xml.atom :id, @staging_id
+  xml.atom :link, rel: 'edit', href: @staging_href
+  xml.sword :treatment, @staging_manifest[:status] == 'awaiting_upload' ? 'Deposit is in progress' : 'Chunk accepted'
+  xml.tag! 'total_size', @staging_manifest[:total_size]
+  xml.tag! 'bytes_received', @staging_manifest[:bytes_received]
+  xml.tag! 'filename', @staging_manifest[:filename]
+  xml.tag! 'status', @staging_manifest[:status]
+end

--- a/config/initializers/willow_sword.rb
+++ b/config/initializers/willow_sword.rb
@@ -19,4 +19,14 @@ WillowSword.setup do |config|
   config.authorize_request = true
   # Default work model when no work model is provided
   config.default_work_model = 'GenericWork'
+  # Maximum size per chunk in bytes (default 90MB, under typical Cloudflare limits)
+  config.max_chunk_size = 90 * 1024 * 1024
+  # How long to keep incomplete chunked uploads before cleanup (seconds)
+  config.chunked_upload_expiry = 24 * 60 * 60
+  # Directory for staging chunked uploads (relative to Rails.root when host app sets cwd to app root).
+  # Default under tmp/network_files so Hyku-style deploys that already mount the uploads volume at
+  # tmp/network_files share staging across web pods without an additional volume mount.
+  config.chunked_upload_path = 'tmp/network_files/willow_sword'
+  # Maximum total file size for a single chunked upload (default 2GB)
+  config.max_total_upload_size = 2 * 1024 * 1024 * 1024
 end

--- a/lib/tasks/willow_sword_tasks.rake
+++ b/lib/tasks/willow_sword_tasks.rake
@@ -1,4 +1,10 @@
-# desc "Explaining what the task does"
-# task :willow_sword do
-#   # Task goes here
-# end
+namespace :willow_sword do
+  desc "Remove chunked upload staging directories older than chunked_upload_expiry (default 24h)"
+  task cleanup_stale_uploads: :environment do
+    handler = Object.new.extend(WillowSword::ChunkedUploadHandler)
+    base = WillowSword.setup.chunked_upload_path || 'tmp/network_files/willow_sword'
+    puts "Scanning #{base} for stale staging entries..."
+    handler.cleanup_stale_uploads
+    puts "Done."
+  end
+end

--- a/lib/willow_sword.rb
+++ b/lib/willow_sword.rb
@@ -2,6 +2,7 @@ require "willow_sword/engine"
 require "willow_sword/bag_package"
 require "willow_sword/zip_package"
 require "willow_sword/error"
+require "willow_sword/sword_error"
 require "willow_sword/dc_crosswalk"
 require "willow_sword/mods_crosswalk"
 require 'willow_sword/hyku_crosswalk'

--- a/lib/willow_sword/error.rb
+++ b/lib/willow_sword/error.rb
@@ -48,6 +48,18 @@ module WillowSword
           iri: 'http://purl.org/net/sword/error/MaxUploadSizeExceeded',
           code: 413
         },
+        chunk_sequence_error: {
+          iri: 'http://purl.org/net/sword/error/ErrorBadRequest',
+          code: 416
+        },
+        upload_not_found: {
+          iri: 'http://purl.org/net/sword/error/ErrorBadRequest',
+          code: 404
+        },
+        upload_incomplete: {
+          iri: 'http://purl.org/net/sword/error/ErrorBadRequest',
+          code: 409
+        },
         not_found: {
           iri: 'http://purl.org/net/sword/error/ErrorBadRequest',
           code: 404

--- a/lib/willow_sword/sword_error.rb
+++ b/lib/willow_sword/sword_error.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module WillowSword
+  class SwordError < StandardError
+    attr_reader :sword_error
+
+    def initialize(error)
+      @sword_error = error
+      super(error.message)
+    end
+  end
+end

--- a/spec/controllers/concerns/willow_sword/process_request_spec.rb
+++ b/spec/controllers/concerns/willow_sword/process_request_spec.rb
@@ -26,5 +26,14 @@ RSpec.describe WillowSword::V2::WorksController, type: :controller do
 
       controller.validate_and_save_request
     end
+
+    it 'routes binary content types to save_binary_data' do
+      controller.instance_variable_set(:@headers, { on_behalf_of: nil })
+      allow(controller.request).to receive(:content_type).and_return('application/octet-stream')
+
+      expect(controller).to receive(:save_binary_data).and_return(true)
+
+      controller.validate_and_save_request
+    end
   end
 end

--- a/spec/lib/willow_sword/chunked_upload_handler_spec.rb
+++ b/spec/lib/willow_sword/chunked_upload_handler_spec.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'willow_sword/error'
+
+RSpec.describe WillowSword::ChunkedUploadHandler do
+  let(:handler) { Object.new.extend(described_class) }
+  let(:upload_base) { Dir.mktmpdir('chunked_uploads_test') }
+
+  before do
+    config = double('config', chunked_upload_path: upload_base, max_chunk_size: 90 * 1024 * 1024, chunked_upload_expiry: 86_400, max_total_upload_size: 2 * 1024 * 1024 * 1024)
+    allow(WillowSword).to receive(:setup).and_return(config)
+  end
+
+  after do
+    FileUtils.rm_rf(upload_base)
+  end
+
+  # Matches production: POST file_sets (In-Progress) + first PUT (Content-Range activates total_size).
+  def staging_id_ready_for_chunks(filename:, total_size:, md5: nil, user_id: 1)
+    uid = handler.initiate_staging(work_id: 'work-1', filename: filename, md5: md5, user_id: user_id)
+    handler.activate_staging(upload_id: uid, total_size: total_size)
+    uid
+  end
+
+  describe '#append_chunk' do
+    let(:upload_id) { staging_id_ready_for_chunks(filename: 'test.bin', total_size: 20, user_id: 1) }
+
+    it 'appends data and updates bytes_received' do
+      body = StringIO.new('0123456789')
+      result = handler.append_chunk(upload_id: upload_id, body_stream: body, content_range: 'bytes 0-9/20')
+
+      expect(result[:bytes_received]).to eq(10)
+      expect(result[:complete]).to be false
+    end
+
+    it 'marks complete when all bytes received' do
+      body1 = StringIO.new('0123456789')
+      handler.append_chunk(upload_id: upload_id, body_stream: body1, content_range: 'bytes 0-9/20')
+
+      body2 = StringIO.new('abcdefghij')
+      result = handler.append_chunk(upload_id: upload_id, body_stream: body2, content_range: 'bytes 10-19/20')
+
+      expect(result[:bytes_received]).to eq(20)
+      expect(result[:complete]).to be true
+
+      payload = File.read(handler.upload_file_path(upload_id))
+      expect(payload).to eq('0123456789abcdefghij')
+    end
+
+    it 'rejects out-of-order chunks' do
+      expect {
+        body = StringIO.new('data')
+        handler.append_chunk(upload_id: upload_id, body_stream: body, content_range: 'bytes 5-8/20')
+      }.to raise_error(WillowSword::SwordError) { |e| expect(e.sword_error.code).to eq(416) }
+    end
+
+    it 'rejects when the request body size does not match Content-Range' do
+      expect {
+        handler.append_chunk(
+          upload_id: upload_id,
+          body_stream: StringIO.new('ab'),
+          content_range: 'bytes 0-9/20'
+        )
+      }.to raise_error(WillowSword::SwordError) { |e| expect(e.sword_error.code).to eq(400) }
+    end
+
+    it 'rejects Content-Range that extends past the declared file size' do
+      expect {
+        handler.append_chunk(
+          upload_id: upload_id,
+          body_stream: StringIO.new('0123456789'),
+          content_range: 'bytes 0-20/20'
+        )
+      }.to raise_error(WillowSword::SwordError) { |e| expect(e.sword_error.code).to eq(400) }
+    end
+
+    it 'rejects an inverted Content-Range (start after end)' do
+      expect {
+        handler.append_chunk(
+          upload_id: upload_id,
+          body_stream: StringIO.new('x'),
+          content_range: 'bytes 5-3/20'
+        )
+      }.to raise_error(WillowSword::SwordError) { |e| expect(e.sword_error.code).to eq(400) }
+    end
+
+    it 'rejects chunks with mismatched total' do
+      expect {
+        body = StringIO.new('data')
+        handler.append_chunk(upload_id: upload_id, body_stream: body, content_range: 'bytes 0-3/999')
+      }.to raise_error(WillowSword::SwordError) { |e| expect(e.sword_error.code).to eq(400) }
+    end
+
+    it 'rejects invalid Content-Range format' do
+      expect {
+        body = StringIO.new('data')
+        handler.append_chunk(upload_id: upload_id, body_stream: body, content_range: 'invalid')
+      }.to raise_error(WillowSword::SwordError) { |e| expect(e.sword_error.code).to eq(400) }
+    end
+
+    it 'raises for unknown upload_id' do
+      expect {
+        handler.append_chunk(upload_id: 'nonexistent', body_stream: StringIO.new('x'), content_range: 'bytes 0-0/1')
+      }.to raise_error(WillowSword::SwordError) { |e| expect(e.sword_error.code).to eq(404) }
+    end
+
+    context 'with md5 checksum' do
+      it 'validates checksum on completion' do
+        data = 'hello world!12345678'
+        md5 = Digest::MD5.hexdigest(data)
+        uid = staging_id_ready_for_chunks(filename: 'test.bin', total_size: 20, md5: md5, user_id: 1)
+
+        result = handler.append_chunk(upload_id: uid, body_stream: StringIO.new(data), content_range: "bytes 0-19/20")
+        expect(result[:complete]).to be true
+      end
+
+      it 'raises on checksum mismatch' do
+        uid = staging_id_ready_for_chunks(filename: 'test.bin', total_size: 5, md5: 'wrong', user_id: 1)
+
+        expect {
+          handler.append_chunk(upload_id: uid, body_stream: StringIO.new('hello'), content_range: 'bytes 0-4/5')
+        }.to raise_error(WillowSword::SwordError) { |e| expect(e.sword_error.code).to eq(412) }
+      end
+    end
+  end
+
+  describe '#upload_status' do
+    it 'returns manifest data for existing upload' do
+      uid = staging_id_ready_for_chunks(filename: 'test.zip', total_size: 100, user_id: 1)
+      status = handler.upload_status(uid)
+
+      expect(status[:filename]).to eq('test.zip')
+      expect(status[:total_size]).to eq(100)
+      expect(status[:status]).to eq('in_progress')
+    end
+
+    it 'returns nil for nonexistent upload' do
+      expect(handler.upload_status('nonexistent')).to be_nil
+    end
+  end
+
+  describe '#upload_complete?' do
+    it 'returns false for in-progress upload' do
+      uid = staging_id_ready_for_chunks(filename: 'test.bin', total_size: 10, user_id: 1)
+      expect(handler.upload_complete?(uid)).to be false
+    end
+
+    it 'returns true for completed upload' do
+      uid = staging_id_ready_for_chunks(filename: 'test.bin', total_size: 5, user_id: 1)
+      handler.append_chunk(upload_id: uid, body_stream: StringIO.new('hello'), content_range: 'bytes 0-4/5')
+      expect(handler.upload_complete?(uid)).to be true
+    end
+  end
+
+  describe '#cancel_upload' do
+    it 'removes the staging directory' do
+      uid = staging_id_ready_for_chunks(filename: 'test.bin', total_size: 10, user_id: 1)
+      expect(File.directory?(File.join(upload_base, uid))).to be true
+
+      handler.cancel_upload(uid)
+      expect(File.directory?(File.join(upload_base, uid))).to be false
+    end
+
+    it 'does not raise for nonexistent upload' do
+      expect { handler.cancel_upload('nonexistent') }.not_to raise_error
+    end
+  end
+
+  describe '#upload_filename' do
+    it 'returns the filename from the manifest' do
+      uid = staging_id_ready_for_chunks(filename: 'deposit.zip', total_size: 100, user_id: 1)
+      expect(handler.upload_filename(uid)).to eq('deposit.zip')
+    end
+  end
+
+  describe '#initiate_staging' do
+    it 'creates a staging directory with awaiting_upload status' do
+      staging_id = handler.initiate_staging(work_id: 'work-1', filename: 'test.zip', user_id: 42)
+
+      expect(staging_id).to be_present
+      expect(File.directory?(File.join(upload_base, staging_id))).to be true
+
+      manifest = JSON.parse(File.read(File.join(upload_base, staging_id, 'manifest.json')), symbolize_names: true)
+      expect(manifest[:work_id]).to eq('work-1')
+      expect(manifest[:filename]).to eq('test.zip')
+      expect(manifest[:user_id]).to eq(42)
+      expect(manifest[:total_size]).to be_nil
+      expect(manifest[:bytes_received]).to eq(0)
+      expect(manifest[:status]).to eq('awaiting_upload')
+    end
+
+    it 'copies metadata file into the staging directory' do
+      metadata_dir = Dir.mktmpdir
+      metadata_path = File.join(metadata_dir, 'metadata.xml')
+      File.write(metadata_path, '<metadata><title>Test</title></metadata>')
+
+      staging_id = handler.initiate_staging(work_id: 'work-1', metadata_path: metadata_path, user_id: 1)
+
+      staged_metadata = File.join(upload_base, staging_id, 'metadata.xml')
+      expect(File.exist?(staged_metadata)).to be true
+      expect(File.read(staged_metadata)).to include('<title>Test</title>')
+    ensure
+      FileUtils.rm_rf(metadata_dir)
+    end
+  end
+
+  describe '#activate_staging' do
+    it 'transitions from awaiting_upload to in_progress with total_size' do
+      staging_id = handler.initiate_staging(work_id: 'work-1', filename: 'test.bin', user_id: 1)
+
+      handler.activate_staging(upload_id: staging_id, total_size: 1000)
+
+      manifest = handler.upload_status(staging_id)
+      expect(manifest[:status]).to eq('in_progress')
+      expect(manifest[:total_size]).to eq(1000)
+    end
+
+    it 'rejects total_size exceeding max' do
+      staging_id = handler.initiate_staging(work_id: 'work-1', filename: 'test.bin', user_id: 1)
+
+      expect {
+        handler.activate_staging(upload_id: staging_id, total_size: 3 * 1024 * 1024 * 1024)
+      }.to raise_error(WillowSword::SwordError) { |e| expect(e.sword_error.code).to eq(413) }
+    end
+  end
+
+  describe '#staging_entry?' do
+    it 'returns true for an existing staging entry' do
+      staging_id = handler.initiate_staging(work_id: 'work-1', user_id: 1)
+      expect(handler.staging_entry?(staging_id)).to be true
+    end
+
+    it 'returns false for nonexistent entry' do
+      expect(handler.staging_entry?('nonexistent')).to be false
+    end
+  end
+
+  describe '#staging_metadata_path' do
+    it 'returns the path when metadata exists' do
+      metadata_dir = Dir.mktmpdir
+      metadata_path = File.join(metadata_dir, 'metadata.xml')
+      File.write(metadata_path, '<metadata/>')
+
+      staging_id = handler.initiate_staging(work_id: 'work-1', metadata_path: metadata_path, user_id: 1)
+
+      result = handler.staging_metadata_path(staging_id)
+      expect(result).to be_present
+      expect(File.exist?(result)).to be true
+    ensure
+      FileUtils.rm_rf(metadata_dir)
+    end
+
+    it 'returns nil when no metadata was staged' do
+      staging_id = handler.initiate_staging(work_id: 'work-1', user_id: 1)
+      expect(handler.staging_metadata_path(staging_id)).to be_nil
+    end
+  end
+
+  describe 'staging + chunk append integration' do
+    it 'accepts chunks after activate_staging' do
+      staging_id = handler.initiate_staging(work_id: 'work-1', filename: 'test.bin', user_id: 1)
+      handler.activate_staging(upload_id: staging_id, total_size: 10)
+
+      result = handler.append_chunk(
+        upload_id: staging_id,
+        body_stream: StringIO.new('0123456789'),
+        content_range: 'bytes 0-9/10'
+      )
+
+      expect(result[:complete]).to be true
+      expect(File.read(handler.upload_file_path(staging_id))).to eq('0123456789')
+    end
+  end
+
+  describe '#cleanup_stale_uploads' do
+    it 'removes uploads older than expiry' do
+      uid = staging_id_ready_for_chunks(filename: 'old.zip', total_size: 100, user_id: 1)
+      manifest_path = File.join(upload_base, uid, 'manifest.json')
+
+      # Backdate the manifest
+      manifest = JSON.parse(File.read(manifest_path), symbolize_names: true)
+      manifest[:created_at] = (Time.current - 2.days).iso8601
+      File.write(manifest_path, JSON.generate(manifest))
+
+      handler.cleanup_stale_uploads
+      expect(File.directory?(File.join(upload_base, uid))).to be false
+    end
+
+    it 'keeps recent uploads' do
+      uid = staging_id_ready_for_chunks(filename: 'new.zip', total_size: 100, user_id: 1)
+
+      handler.cleanup_stale_uploads
+      expect(File.directory?(File.join(upload_base, uid))).to be true
+    end
+  end
+end

--- a/spec/lib/willow_sword/error_spec.rb
+++ b/spec/lib/willow_sword/error_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe WillowSword::Error do
       expect(error.errors).to include(:mediation_not_allowed)
       expect(error.errors).to include(:method_not_allowed)
       expect(error.errors).to include(:max_upload_size_exceeded)
+      expect(error.errors).to include(:chunk_sequence_error)
+      expect(error.errors).to include(:upload_not_found)
+      expect(error.errors).to include(:upload_incomplete)
       expect(error.errors).to include(:not_found)
       expect(error.errors).to include(:default)
     end
@@ -103,6 +106,30 @@ RSpec.describe WillowSword::Error do
       error = WillowSword::Error.new(msg, :max_upload_size_exceeded)
       expect(error.iri).to eq('http://purl.org/net/sword/error/MaxUploadSizeExceeded')
       expect(error.code).to eq 413
+      expect(error.message).to eq msg
+    end
+
+    it "should return error of type chunk_sequence_error" do
+      msg = 'chunk sequence error'
+      error = WillowSword::Error.new(msg, :chunk_sequence_error)
+      expect(error.iri).to eq('http://purl.org/net/sword/error/ErrorBadRequest')
+      expect(error.code).to eq 416
+      expect(error.message).to eq msg
+    end
+
+    it "should return error of type upload_not_found" do
+      msg = 'upload not found'
+      error = WillowSword::Error.new(msg, :upload_not_found)
+      expect(error.iri).to eq('http://purl.org/net/sword/error/ErrorBadRequest')
+      expect(error.code).to eq 404
+      expect(error.message).to eq msg
+    end
+
+    it "should return error of type upload_incomplete" do
+      msg = 'upload incomplete'
+      error = WillowSword::Error.new(msg, :upload_incomplete)
+      expect(error.iri).to eq('http://purl.org/net/sword/error/ErrorBadRequest')
+      expect(error.code).to eq 409
       expect(error.message).to eq msg
     end
 

--- a/spec/request/v1/chunked_deposit_spec.rb
+++ b/spec/request/v1/chunked_deposit_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+RSpec.describe 'SWORD V1 Chunked Deposit (end-to-end)', type: :request do
+  let(:upload_base) { Dir.mktmpdir('chunked_uploads_test') }
+
+  before do
+    create(:admin, email: 'admin@example.com', api_key: 'test')
+    @previous_chunked_upload_path = WillowSword.setup.chunked_upload_path
+    WillowSword.setup.chunked_upload_path = upload_base
+  end
+
+  after do
+    WillowSword.setup.chunked_upload_path = @previous_chunked_upload_path
+    FileUtils.rm_rf(upload_base)
+  end
+
+  describe 'chunked file set creation via legacy SWORD routes' do
+    let!(:admin_set_id) { valkyrie_create(:default_hyrax_admin_set).id.to_s }
+    let(:zip_path) { WillowSword::Engine.root.join('spec', 'fixtures', 'testPackage.zip') }
+    let(:zip_data) { File.binread(zip_path) }
+    let(:zip_size) { zip_data.bytesize }
+    let!(:work) { valkyrie_create(:hyrax_work, id: 'v1-work-1', title: ['Test Work']) }
+
+    it 'creates a file set by posting metadata then uploading chunks' do
+      collection_id = admin_set_id
+      work_id = work.id.to_s
+
+      # Step 1: POST to file_sets with In-Progress: true to initiate staging
+      post "/sword/collections/#{collection_id}/works/#{work_id}/file_sets", headers: {
+        'Api-key' => 'test',
+        'Content-Disposition' => 'attachment; filename=testPackage.zip',
+        'In-Progress' => 'true'
+      }
+
+      expect(response).to have_http_status(:created)
+      doc = Nokogiri::XML(response.body)
+      staging_id = doc.at_xpath('//atom:id', 'atom' => 'http://www.w3.org/2005/Atom').text
+      expect(staging_id).to be_present
+      expect(doc.at_xpath('//status').text).to eq('awaiting_upload')
+
+      # Step 2: Upload file in two chunks via PUT
+      mid = zip_size / 2
+      chunk1 = zip_data[0...mid]
+      chunk2 = zip_data[mid..]
+
+      put "/sword/collections/#{collection_id}/works/#{work_id}/file_sets/#{staging_id}", headers: {
+        'Api-key' => 'test',
+        'Content-Range' => "bytes 0-#{mid - 1}/#{zip_size}",
+        'Content-Type' => 'application/octet-stream',
+        'In-Progress' => 'true'
+      }, params: chunk1
+
+      expect(response).to have_http_status(:ok)
+      doc = Nokogiri::XML(response.body)
+      expect(doc.at_xpath('//status').text).to eq('in_progress')
+      expect(doc.at_xpath('//bytes_received').text).to eq(mid.to_s)
+
+      # Step 3: Upload final chunk with In-Progress: false
+      put "/sword/collections/#{collection_id}/works/#{work_id}/file_sets/#{staging_id}", headers: {
+        'Api-key' => 'test',
+        'Content-Range' => "bytes #{mid}-#{zip_size - 1}/#{zip_size}",
+        'Content-Type' => 'application/octet-stream',
+        'In-Progress' => 'false'
+      }, params: chunk2
+
+      expect(response).to have_http_status(:created)
+
+      # Verify the response is a proper SWORD Atom feed for the created FileSet
+      doc = Nokogiri::XML(response.body)
+      expect(doc.root.name).to eq('feed')
+
+      # Verify FileSet is attached to the work
+      updated_work = Hyrax.query_service.find_by(id: work_id)
+      expect(updated_work.member_ids).not_to be_empty
+
+      # Verify staging directory is cleaned up
+      expect(File.exist?(File.join(upload_base, staging_id))).to be false
+    end
+
+    it 'returns staging status on GET during upload' do
+      collection_id = admin_set_id
+      work_id = work.id.to_s
+
+      # Create staging entry
+      post "/sword/collections/#{collection_id}/works/#{work_id}/file_sets", headers: {
+        'Api-key' => 'test',
+        'Content-Disposition' => 'attachment; filename=test.zip',
+        'In-Progress' => 'true'
+      }
+
+      expect(response).to have_http_status(:created)
+      doc = Nokogiri::XML(response.body)
+      staging_id = doc.at_xpath('//atom:id', 'atom' => 'http://www.w3.org/2005/Atom').text
+
+      # GET the staging entry
+      get "/sword/collections/#{collection_id}/works/#{work_id}/file_sets/#{staging_id}", headers: { 'Api-key' => 'test' }
+
+      expect(response).to have_http_status(:ok)
+      doc = Nokogiri::XML(response.body)
+      expect(doc.at_xpath('//status').text).to eq('awaiting_upload')
+      expect(doc.at_xpath('//filename').text).to eq('test.zip')
+    end
+  end
+end

--- a/spec/request/v2/chunked_deposit_spec.rb
+++ b/spec/request/v2/chunked_deposit_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+RSpec.describe 'SWORD Chunked Deposit (end-to-end)', type: :request do
+  let(:upload_base) { Dir.mktmpdir('chunked_uploads_test') }
+
+  before do
+    create(:admin, email: 'admin@example.com', api_key: 'test')
+    @previous_chunked_upload_path = WillowSword.setup.chunked_upload_path
+    WillowSword.setup.chunked_upload_path = upload_base
+  end
+
+  after do
+    WillowSword.setup.chunked_upload_path = @previous_chunked_upload_path
+    FileUtils.rm_rf(upload_base)
+  end
+
+  describe 'chunked file set creation via SWORD protocol' do
+    let!(:admin_set_id) { valkyrie_create(:default_hyrax_admin_set).id.to_s }
+    let(:zip_path) { WillowSword::Engine.root.join('spec', 'fixtures', 'v2', 'testPackage.zip') }
+    let(:zip_data) { File.binread(zip_path) }
+    let(:zip_size) { zip_data.bytesize }
+    let(:metadata) { File.read(WillowSword::Engine.root.join('spec', 'fixtures', 'v2', 'metadata.xml')) }
+
+    it 'creates a file set by posting metadata then uploading chunks' do
+      # Step 1: Create work first (standard SWORD deposit)
+      post "/sword/v2/collections/#{admin_set_id}/works", headers: {
+        'Api-key' => 'test',
+        'Content-Type' => 'application/xml',
+        'In-Progress' => 'false'
+      }, params: metadata
+
+      expect(response).to have_http_status(:created)
+      doc = Nokogiri::XML(response.body)
+      work_id = doc.root.xpath('atom:id', 'atom' => 'http://www.w3.org/2005/Atom').text
+      expect(work_id).to be_present
+
+      # Step 2: POST metadata-only to file_sets with In-Progress: true
+      file_set_metadata = <<~XML
+        <metadata>
+          <title>Chunked Upload File</title>
+        </metadata>
+      XML
+
+      post "/sword/v2/works/#{work_id}/file_sets", headers: {
+        'Api-key' => 'test',
+        'Content-Type' => 'application/xml',
+        'Content-Disposition' => 'attachment; filename=testPackage.zip',
+        'In-Progress' => 'true'
+      }, params: file_set_metadata
+
+      expect(response).to have_http_status(:created)
+      doc = Nokogiri::XML(response.body)
+      staging_id = doc.at_xpath('//atom:id', 'atom' => 'http://www.w3.org/2005/Atom').text
+      expect(staging_id).to be_present
+      expect(doc.at_xpath('//status').text).to eq('awaiting_upload')
+
+      # Step 3: Upload file in two chunks via PUT to file_sets/:staging_id
+      mid = zip_size / 2
+      chunk1 = zip_data[0...mid]
+      chunk2 = zip_data[mid..]
+
+      put "/sword/v2/file_sets/#{staging_id}", headers: {
+        'Api-key' => 'test',
+        'Content-Range' => "bytes 0-#{mid - 1}/#{zip_size}",
+        'Content-Type' => 'application/octet-stream',
+        'In-Progress' => 'true'
+      }, params: chunk1
+
+      expect(response).to have_http_status(:ok)
+      doc = Nokogiri::XML(response.body)
+      expect(doc.at_xpath('//status').text).to eq('in_progress')
+      expect(doc.at_xpath('//bytes_received').text).to eq(mid.to_s)
+
+      # Step 4: Upload final chunk with In-Progress: false
+      put "/sword/v2/file_sets/#{staging_id}", headers: {
+        'Api-key' => 'test',
+        'Content-Range' => "bytes #{mid}-#{zip_size - 1}/#{zip_size}",
+        'Content-Type' => 'application/octet-stream',
+        'In-Progress' => 'false'
+      }, params: chunk2
+
+      expect(response).to have_http_status(:created)
+
+      # Verify the response is a proper SWORD entry for the created FileSet
+      doc = Nokogiri::XML(response.body)
+      expect(doc.root.name).to eq('entry')
+      file_set_id = doc.root.xpath('atom:id', 'atom' => 'http://www.w3.org/2005/Atom').text
+      expect(file_set_id).to be_present
+
+      # Verify FileSet is attached to the work
+      work = Hyrax.query_service.find_by(id: work_id)
+      expect(work.member_ids).not_to be_empty
+
+      # Verify staging directory is cleaned up
+      expect(File.exist?(File.join(upload_base, staging_id))).to be false
+    end
+
+    it 'returns staging status on GET during upload' do
+      # Create work
+      post "/sword/v2/collections/#{admin_set_id}/works", headers: {
+        'Api-key' => 'test',
+        'Content-Type' => 'application/xml',
+        'In-Progress' => 'false'
+      }, params: metadata
+      doc = Nokogiri::XML(response.body)
+      work_id = doc.root.xpath('atom:id', 'atom' => 'http://www.w3.org/2005/Atom').text
+
+      # Create staging entry
+      post "/sword/v2/works/#{work_id}/file_sets", headers: {
+        'Api-key' => 'test',
+        'Content-Type' => 'application/xml',
+        'Content-Disposition' => 'attachment; filename=test.zip',
+        'In-Progress' => 'true'
+      }, params: '<metadata><title>Test</title></metadata>'
+      doc = Nokogiri::XML(response.body)
+      staging_id = doc.at_xpath('//atom:id', 'atom' => 'http://www.w3.org/2005/Atom').text
+
+      # GET the staging entry
+      get "/sword/v2/file_sets/#{staging_id}", headers: { 'Api-key' => 'test' }
+
+      expect(response).to have_http_status(:ok)
+      doc = Nokogiri::XML(response.body)
+      expect(doc.at_xpath('//status').text).to eq('awaiting_upload')
+      expect(doc.at_xpath('//filename').text).to eq('test.zip')
+    end
+  end
+end


### PR DESCRIPTION
# Summary

Extends the chunked upload feature (V2) to also work on the legacy SWORD routes. The protocol is identical — `In-Progress: true` to initiate staging, `PUT` with `Content-Range` to send chunks, `In-Progress: false` to finalize — only the URLs differ.

| Step | V2 route | Legacy route |
|------|----------|-------------|
| Initiate staging | `POST /sword/v2/works/{WID}/file_sets` | `POST /sword/collections/{CID}/works/{WID}/file_sets` |
| Send chunks | `PUT /sword/v2/file_sets/{STAGING_ID}` | `PUT /sword/collections/{CID}/works/{WID}/file_sets/{STAGING_ID}` |
| Check status | `GET /sword/v2/file_sets/{STAGING_ID}` | `GET /sword/collections/{CID}/works/{WID}/file_sets/{STAGING_ID}` |

Non-chunked `POST`/`PUT` behavior for works and file sets is unchanged on both legacy and V2.

## What changed

1. **`WillowSword::SwordError`** — new `StandardError` subclass wrapping `WillowSword::Error`. Required by `ChunkedUploadHandler` (was referenced but never defined). Also added missing error types: `:chunk_sequence_error` (416), `:upload_not_found` (404), `:upload_incomplete` (409).

2. **Shared staging status view** — moved `staging_status.xml.builder` from `v2/file_sets/` to `shared/` so both legacy and V2 controllers render the same SWORD staging XML.

3. **`collection_id` in staging manifest** — legacy routes are nested under `/collections/{CID}/works/{WID}/`, so the collection ID is stored in the manifest alongside `work_id` for use in response URL generation. The new `collection_id:` keyword arg defaults to `nil`, so V2 callers are unaffected.

4. **Legacy `FileSetsController`** — includes `ChunkedUploadHandler` and adds chunking support to `create`, `show`, and `update`. The V2 controller inherits this include so the redundant include there is removed. Uses `rescue_from SwordError` (narrowly scoped) rather than the V2 `HandleError` concern to avoid changing existing legacy error handling. Renders legacy Atom feed XML on finalization, not HykuCrosswalk.

5. **`with_manifest_lock` fix** — when `append_chunk` is called with a nonexistent upload ID, the staging directory doesn't exist, so `File.open` on the `.lock` file raised `Errno::ENOENT`. Now checks directory existence first and raises the expected `SwordError(:upload_not_found)`.

The V2 controller completely overrides `create`/`show`/`update`, so base controller changes do not affect V2 behavior.

## Kirk's review shortcut

12 of the 17 files are unchanged from your PR #59 review. The new work is 5 files:
- `app/controllers/willow_sword/file_sets_controller.rb` — legacy chunking support (main change)
- `app/views/willow_sword/shared/staging_status.xml.builder` — moved from `v2/file_sets/`, same content
- `app/controllers/concerns/willow_sword/chunked_upload_handler.rb` — 2 small additions: `collection_id:` param + directory check in `with_manifest_lock`
- `lib/willow_sword/sword_error.rb` — new 12-line file
- `spec/request/legacy/chunked_deposit_spec.rb` — new legacy integration test

## Ticket Number

- [palni_palci_knapsack#617](https://github.com/notch8/palni_palci_knapsack/issues/617)

## Test Results

Tested all four scenarios on `pittir-staging.hykucommons.org` (2026-05-05):

| # | Test | Route | HTTP Codes | Result |
|---|------|-------|------------|--------|
| 1 | Non-chunked file set upload | V2 | 201 (work), 201 (file set) | **PASS** |
| 2 | Chunked file set upload (2 chunks) | V2 | 201 (staging), 200 (chunk), 201 (finalize) | **PASS** |
| 3 | Non-chunked file set upload | Legacy | 201 (work), 201 (file set) | **PASS** |
| 4 | Chunked file set upload (2 chunks) | Legacy | 201 (staging), 200 (status), 200 (chunk), 201 (finalize) | **PASS** |

## Expected Behavior

- **Default deposits unchanged:** single `POST` to create a work or attach a file set, without `In-Progress`/`Content-Range` headers, behaves exactly as before on both legacy and V2.
- **Chunked file set uploads (legacy):** same protocol as V2 — `POST` with `In-Progress: true` to initiate staging, `PUT` with `Content-Range` to send chunks, final `PUT` with `In-Progress: false` to finalize. Legacy URLs are nested (`/collections/{CID}/works/{WID}/file_sets/{STAGING_ID}`), and finalization renders the legacy Atom feed XML format.
- **Staging:** shared `tmp/network_files/...` works across pods; `flock` on `.lock` does not error on EFS/NFS.
- **Cleanup:** `CleanupStaleUploadsJob` and the rake task work the same as before.