### PR TITLE
Remove hardcoded terms

### DIFF
--- a/app/views/willow_sword/file_sets/show.xml.builder
+++ b/app/views/willow_sword/file_sets/show.xml.builder
@@ -30,17 +30,8 @@ if WillowSword.config.xml_mapping_read == 'Hyku'
       end
     end
 
-    # Add dc and dcterms
-    xw.dc_terms.each do |term|
-      Array.wrap(@file_set.send(term)).each do |val|
-        val = val.to_s
-        next if val.blank?
-
-        prefix = xw.dc_terms_to_fallback_to_dc.include?(term) ? 'dc' : xw.prefix_lookup_for(term)
-        translated_term = xw.term_translation_mappings[term] || term
-        xml.tag!(:"#{prefix}:#{translated_term}", val)
-      end
-    end
+    # Add dc and dcterms (driven by M3 schema mappings)
+    xw.add_dc_metadata_to_xml(xml)
   end
 else
   xml.feed(xmlns:"http://www.w3.org/2005/Atom",

--- a/app/views/willow_sword/works/show.xml+hyku.builder
+++ b/app/views/willow_sword/works/show.xml+hyku.builder
@@ -37,15 +37,6 @@ xml.feed(xw.namespace_declarations) do
     end
   end
 
-  # Add dc and dcterms
-  xw.dc_terms.each do |term|
-    Array.wrap(@object.send(term)).each do |val|
-      val = val.to_s
-      next if val.blank?
-
-      prefix = xw.dc_terms_to_fallback_to_dc.include?(term) ? 'dc' : xw.prefix_lookup_for(term)
-      translated_term = xw.term_translation_mappings[term] || term
-      xml.tag!(:"#{prefix}:#{translated_term}", val)
-    end
-  end
+  # Add dc and dcterms (driven by M3 schema mappings)
+  xw.add_dc_metadata_to_xml(xml)
 end

--- a/lib/willow_sword/hyku_crosswalk.rb
+++ b/lib/willow_sword/hyku_crosswalk.rb
@@ -48,70 +48,22 @@ module WillowSword
          date_uploaded depositor state).select { |term| work.respond_to?(term) }
     end
 
-    # @returns [Array<String>] a list of Dublin Core terms used in the work
-    def dc_terms
-      (terms + system_terms).uniq.select do |term|
-        prefix_lookup_for(term) == 'dc' || prefix_lookup_for(term) == 'dcterms' || dc_terms_to_fallback_to_dc.include?(term)
+    # Renders dc and dcterms metadata driven entirely by the M3 schema's
+    # `mappings.simple_dc_pmh` and `mappings.qualified_dc_pmh` declarations.
+    # A term with no mapping in either is not emitted under dc/dcterms.
+    def add_dc_metadata_to_xml(xml)
+      simple_mappings = simple_dc_mappings_from_schema
+      qualified_mappings = qualified_dc_mappings_from_schema
+      schema_terms = (simple_mappings.keys + qualified_mappings.keys).uniq.select { |t| work.respond_to?(t) }
+
+      schema_terms.each do |term|
+        Array.wrap(work.send(term)).each do |val|
+          val = val.to_s
+          next if val.blank?
+
+          render_dc_term(xml, term, val, simple_mappings, qualified_mappings)
+        end
       end
-    end
-
-    # @returns [Hash] a hash of term translations for the work's schema
-    def term_translation_mappings
-      {
-        'date_modified'          => 'modified',
-        'date_uploaded'          => 'dateSubmitted',
-        'depositor'              => 'dpt',
-        'access_right'           => 'accessRights',
-        'alternative_title'      => 'alternative',
-        'bibliographic_citation' => 'bibliographicCitation',
-        'date_created'           => 'date',
-        'import_url'             => 'importUrl',
-        'keyword'                => 'keywords',
-        'label'                  => 'downloadFilename',
-        'related_url'            => 'seeAlso',
-        'rights_statement'       => 'rights',
-        'resource_type'          => 'type',
-        'rights_notes'           => 'rights',
-        'additional_information' => 'accessRights',
-        'admin_note'             => 'positiveNotes',
-        'education_level'        => 'educationLevel',
-        'learning_resource_type' => 'learningResourceType',
-        'discipline'             => 'degree_discipline',
-        'accessibility_feature'  => 'accessibilityFeature',
-        'accessibility_hazard'   => 'accessibilityHazard',
-        'accessibility_summary'  => 'accessibilitySummary',
-        'oer_size'               => 'extent',
-        'rights_holder'          => 'rightsHolder',
-        'table_of_contents'      => 'tableOfContents',
-        'previous_version_id'    => 'replaces',
-        'newer_version_id'       => 'isReplacedBy',
-        'alternate_version_id'   => 'hasVersion',
-        'related_item_id'        => 'relation'
-      }
-    end
-
-    # DC Terms is a superset of Dublin Core, meaning all original DC elements
-    # are also available in the DC Terms namespace. Initially, the plan was to
-    # support only DC Terms (`dcterms`), but metadata experts pointed out that
-    # legacy clients may only recognize the older DC (`dc`) namespace.
-    #
-    # To ensure compatibility, this method lists the Hyrax/Hyku terms that
-    # should fallback to `dc` even if their predicates are assigned to `dcterms`.
-    #
-    # Example XML output:
-    #   <dc:title>Test Record</dc:title>
-    #
-    # Instead of:
-    #   <dcterms:title>Test Record</dcterms:title>
-    #
-    # The `dc` version ensures backward compatibility.
-    #
-    # @return [Array<String>] An array of Hyrax/Hyku terms that the work responds to
-    #   that should be mapped to `dc` even if it's considered `dcterms` by Hyrax/Hyku.
-    def dc_terms_to_fallback_to_dc
-      %w(contributor coverage creator date_created description format
-         identifier language publisher related_item_id rights_holder source
-         rights_notes rights_statement subject title resource_type).select { |term| work.respond_to?(term) }
     end
 
     # Convert the visibility to read either 'embargo' or 'lease' when active.
@@ -148,6 +100,34 @@ module WillowSword
     # @returns [Array<String>] a list of terms from the work's schema
     def terms_from_schema
       work_klass.schema.keys.map { |field| field.name.to_s }
+    end
+
+    def simple_dc_mappings_from_schema
+      dc_mappings_from_schema('simple_dc_pmh')
+    end
+
+    def qualified_dc_mappings_from_schema
+      dc_mappings_from_schema('qualified_dc_pmh')
+    end
+
+    def dc_mappings_from_schema(key)
+      work_klass.schema.keys.each_with_object({}) do |field, h|
+        val = field.meta&.dig('mappings', key)
+        h[field.name.to_s] = val if val
+      end
+    end
+
+    def render_dc_term(xml, term, val, simple_mappings, qualified_mappings)
+      seen_keys = []
+
+      [simple_mappings[term], qualified_mappings[term]].compact.each do |mapping_value|
+        prefix, local = mapping_value.split(':', 2)
+        key = "#{prefix}:#{local}"
+        next if seen_keys.include?(key)
+
+        xml.tag!(:"#{key}", val)
+        seen_keys << key
+      end
     end
 
     # @returns [Array<String>] a list of terms used in the work to be included in the crosswalk

--- a/lib/willow_sword/v2/hyku_crosswalk.rb
+++ b/lib/willow_sword/v2/hyku_crosswalk.rb
@@ -53,49 +53,6 @@ module WillowSword
           date_uploaded depositor state label).select { |term| terms_from_schema.include?(term) }
       end
 
-      # @returns [Array<String>] a list of Dublin Core terms used in the object
-      def dc_terms
-        @dc_terms ||= (terms + system_terms).uniq.select do |term|
-          prefix = prefix_lookup_for(term)
-          prefix == 'dc' || prefix == 'dcterms' || dc_terms_to_fallback_to_dc.include?(term)
-        end
-      end
-
-      # @returns [Hash] a hash of term translations for the object's schema
-      def term_translation_mappings
-        @term_translation_mappings ||= {
-          'date_modified'          => 'modified',
-          'date_uploaded'          => 'dateSubmitted',
-          'depositor'              => 'dpt',
-          'access_right'           => 'accessRights',
-          'alternative_title'      => 'alternative',
-          'bibliographic_citation' => 'bibliographicCitation',
-          'date_created'           => 'date',
-          'import_url'             => 'importUrl',
-          'keyword'                => 'keywords',
-          'label'                  => 'downloadFilename',
-          'related_url'            => 'seeAlso',
-          'rights_statement'       => 'rights',
-          'resource_type'          => 'type',
-          'rights_notes'           => 'rights',
-          'additional_information' => 'accessRights',
-          'admin_note'             => 'positiveNotes',
-          'education_level'        => 'educationLevel',
-          'learning_resource_type' => 'learningResourceType',
-          'discipline'             => 'degree_discipline',
-          'accessibility_feature'  => 'accessibilityFeature',
-          'accessibility_hazard'   => 'accessibilityHazard',
-          'accessibility_summary'  => 'accessibilitySummary',
-          'oer_size'               => 'extent',
-          'rights_holder'          => 'rightsHolder',
-          'table_of_contents'      => 'tableOfContents',
-          'previous_version_id'    => 'replaces',
-          'newer_version_id'       => 'isReplacedBy',
-          'alternate_version_id'   => 'hasVersion',
-          'related_item_id'        => 'relation'
-        }
-      end
-
       def translated_terms
         {
           'created' =>'date_created',
@@ -107,30 +64,6 @@ module WillowSword
 
       def singular
         object_klass.user_settable_attributes.map(&:to_s) - object_klass.multiple_attributes.map(&:to_s) + visibility_terms
-      end
-
-      # DC Terms is a superset of Dublin Core, meaning all original DC elements
-      # are also available in the DC Terms namespace. Initially, the plan was to
-      # support only DC Terms (`dcterms`), but metadata experts pointed out that
-      # legacy clients may only recognize the older DC (`dc`) namespace.
-      #
-      # To ensure compatibility, this method lists the Hyrax/Hyku terms that
-      # should fallback to `dc` even if their predicates are assigned to `dcterms`.
-      #
-      # Example XML output:
-      #   <dc:title>Test Record</dc:title>
-      #
-      # Instead of:
-      #   <dcterms:title>Test Record</dcterms:title>
-      #
-      # The `dc` version ensures backward compatibility.
-      #
-      # @return [Array<String>] An array of Hyrax/Hyku terms that the object responds to
-      #   that should be mapped to `dc` even if it's considered `dcterms` by Hyrax/Hyku.
-      def dc_terms_to_fallback_to_dc
-        @dc_terms_to_fallback_to_dc ||= %w(contributor coverage creator date_created description format
-          identifier language publisher related_item_id rights_holder source
-          rights_notes rights_statement subject title resource_type).select { |term| object.respond_to?(term) }
       end
 
       def map_xml
@@ -195,13 +128,15 @@ module WillowSword
         end
       end
 
-      # Renders dc and dcterms metadata.
+      # Renders dc and dcterms metadata driven entirely by the M3 schema's
+      # `mappings.simple_dc_pmh` and `mappings.qualified_dc_pmh` declarations.
+      # A term with no mapping in either is not emitted under dc/dcterms.
       def add_dc_metadata_to_xml(xml)
         simple_mappings = simple_dc_mappings_from_schema
         qualified_mappings = qualified_dc_mappings_from_schema
         schema_terms = (simple_mappings.keys + qualified_mappings.keys).uniq.select { |t| @object.respond_to?(t) }
 
-        (dc_terms + schema_terms).uniq.each do |term|
+        schema_terms.each do |term|
           Array.wrap(@object.send(term)).each do |val|
             val = val.to_s
             next if val.blank?
@@ -222,15 +157,6 @@ module WillowSword
           xml.tag!(:"#{key}", val)
           seen_keys << key
         end
-
-        return unless dc_terms.include?(term)
-
-        prefix = dc_terms_to_fallback_to_dc.include?(term) ? 'dc' : prefix_lookup_for(term)
-        translated_term = term_translation_mappings[term] || term
-        key = "#{prefix}:#{translated_term}"
-        return if seen_keys.include?(key)
-
-        xml.tag!(:"#{key}", val)
       end
 
       # Takes the object's schema and returns a hash of predicate mappings for terms

--- a/spec/lib/willow_sword/hyku_crosswalk_spec.rb
+++ b/spec/lib/willow_sword/hyku_crosswalk_spec.rb
@@ -53,24 +53,35 @@ RSpec.describe WillowSword::HykuCrosswalk, type: :request do
     end
   end
 
-  describe '#dc_terms' do
-    it 'includes dublin core terms' do
-      expect(xw.dc_terms).to include(
-        'title', 'creator', 'description',
-        'identifier', 'publisher', 'language'
-      )
-    end
-  end
+  describe '#add_dc_metadata_to_xml' do
+    let(:xml) { Builder::XmlMarkup.new }
+    let(:doc) { Nokogiri::XML("<root xmlns:dc='http://purl.org/dc/elements/1.1/' xmlns:dcterms='http://purl.org/dc/terms/'>#{xml.target!}</root>") }
+    let(:ns) { { 'dc' => 'http://purl.org/dc/elements/1.1/', 'dcterms' => 'http://purl.org/dc/terms/' } }
 
-  describe '#term_translation_mappings' do
-    it 'returns hash of Hyrax/Hyku property keys and translated values' do
-      mappings = xw.term_translation_mappings
-      expect(mappings).to include(
-        'date_modified' => 'modified',
-        'date_uploaded' => 'dateSubmitted',
-        'access_right' => 'accessRights',
-        'alternative_title' => 'alternative'
-      )
+    context 'when the schema declares simple_dc_pmh / qualified_dc_pmh mappings' do
+      before do
+        patched_keys = work.class.schema.keys.map do |k|
+          next k unless k.name.to_s == 'title'
+
+          patched_meta = (k.meta || {}).merge(
+            'mappings' => { 'simple_dc_pmh' => 'dc:title', 'qualified_dc_pmh' => 'dcterms:title' }
+          )
+          Struct.new(:name, :meta).new(k.name, patched_meta)
+        end
+        allow(work.class).to receive(:schema).and_return(double('Schema', keys: patched_keys))
+      end
+
+      it 'renders <dc:title> and <dcterms:title>' do
+        xw.add_dc_metadata_to_xml(xml)
+        expect(doc.root.xpath('dc:title', ns).text).to eq 'Test Title'
+        expect(doc.root.xpath('dcterms:title', ns).text).to eq 'Test Title'
+      end
+    end
+
+    it 'emits nothing for terms without schema mappings' do
+      xw.add_dc_metadata_to_xml(xml)
+      expect(doc.root.xpath('dc:*', ns)).to be_empty
+      expect(doc.root.xpath('dcterms:*', ns)).to be_empty
     end
   end
 

--- a/spec/request/v2/file_sets_spec.rb
+++ b/spec/request/v2/file_sets_spec.rb
@@ -29,23 +29,23 @@ RSpec.describe 'SWORD FileSets', type: :request do
       expect(doc.root.xpath('h4csys:label', ns).text).to eq 'image.png'
     end
 
-    it 'renders file set metadata as DC terms' do
+    it 'renders settable + system metadata under h4cmeta / h4csys' do
       get "/sword/v2/file_sets/#{file_set.id}", headers: { 'Api-key' => 'test' }
 
       doc = Nokogiri::XML(response.body)
 
-      # File set title is mapped to dc:title via the DC fallback
-      expect(doc.root.xpath('dc:title', ns).text).to eq 'Test File Set'
-
-      # File set creator is mapped to dc:creator via the DC fallback
-      expect(doc.root.xpath('dc:creator', ns).text).to eq 'admin@example.com'
-
-      # Settable metadata is also rendered under h4cmeta
       expect(doc.root.xpath('h4cmeta:title', ns).text).to eq 'Test File Set'
       expect(doc.root.xpath('h4cmeta:creator', ns).text).to eq 'admin@example.com'
-
-      # System metadata is rendered under h4csys
       expect(doc.root.xpath('h4csys:internal_resource', ns).text).to eq 'FileSet'
+    end
+
+    it 'does not emit dc/dcterms for terms without schema mappings' do
+      get "/sword/v2/file_sets/#{file_set.id}", headers: { 'Api-key' => 'test' }
+
+      doc = Nokogiri::XML(response.body)
+
+      expect(doc.root.xpath('dc:title', ns)).to be_empty
+      expect(doc.root.xpath('dc:creator', ns)).to be_empty
     end
 
     context 'when the schema declares simple_dc_pmh / qualified_dc_pmh mappings' do
@@ -128,17 +128,15 @@ RSpec.describe 'SWORD FileSets', type: :request do
         File.read(WillowSword::Engine.root.join('spec', 'fixtures', 'v2', 'fileSetTestPackage.zip'))
       end
 
-      it 'renders created file set metadata as DC terms' do
+      it 'renders created file set metadata under h4cmeta / h4csys' do
         post '/sword/v2/works/work-1/file_sets', headers: headers, params: params
 
         doc = Nokogiri::XML(response.body)
         ns = {
-          'dc' => 'http://purl.org/dc/elements/1.1/',
           'h4cmeta' => 'https://hykucommons.org/schema/metadata',
           'h4csys' => 'https://hykucommons.org/schema/system'
         }
 
-        expect(doc.root.xpath('dc:title', ns).text).to eq 'My title'
         expect(doc.root.xpath('h4cmeta:title', ns).text).to eq 'My title'
         expect(doc.root.xpath('h4csys:internal_resource', ns).text).to eq 'FileSet'
       end
@@ -221,17 +219,6 @@ RSpec.describe 'SWORD FileSets', type: :request do
       expect(doc.root.xpath('h4cmeta:visibility_after_embargo', ns).text).to eq('authenticated')
       expect(doc.root.xpath('h4cmeta:visibility_during_embargo', ns).text).to eq('restricted')
       expect(doc.root.xpath('h4cmeta:creator', ns).text).to eq('someone_else@example.com')
-    end
-
-    it 'renders updated metadata as DC terms' do
-      allow_any_instance_of(Hyrax::FileMetadata).to receive(:mime_type).and_return('image/png')
-
-      put "/sword/v2/file_sets/#{file_set.id}", headers: headers, params: params
-
-      doc = Nokogiri::XML(response.body)
-
-      expect(doc.root.xpath('dc:title', ns).text).to eq 'Updated FileSet Title'
-      expect(doc.root.xpath('dc:creator', ns).text).to eq 'someone_else@example.com'
     end
 
     context 'when the schema declares simple_dc_pmh / qualified_dc_pmh mappings' do

--- a/spec/request/v2/works_spec.rb
+++ b/spec/request/v2/works_spec.rb
@@ -75,33 +75,61 @@ RSpec.describe 'SWORD Works', type: :request do
     end
 
     context 'when the schema declares simple_dc_pmh / qualified_dc_pmh mappings' do
-      before do
+      def patch_schema_mappings(mappings_by_term)
         patched_keys = Monograph.schema.keys.map do |k|
-          next k unless k.name.to_s == 'title'
+          override = mappings_by_term[k.name.to_s]
+          next k unless override
 
-          patched_meta = k.meta.merge(
-            'mappings' => {
-              'simple_dc_pmh' => 'dc:title',
-              'qualified_dc_pmh' => 'dcterms:title'
-            }
-          )
-          Struct.new(:name, :meta).new(k.name, patched_meta)
+          Struct.new(:name, :meta).new(k.name, k.meta.merge('mappings' => override))
         end
         patched_schema = double('Schema', keys: patched_keys)
         allow_any_instance_of(WillowSword::V2::HykuCrosswalk)
           .to receive(:object_schema).and_return(patched_schema)
       end
 
-      it 'renders <dc:title> and <dcterms:title> per the schema mappings' do
-        get '/sword/v2/works/work-123', headers: { 'Api-key' => 'test' }
-
-        doc = Nokogiri::XML(response.body)
-        ns = {
+      let(:ns) do
+        {
           'dc' => 'http://purl.org/dc/elements/1.1/',
           'dcterms' => 'http://purl.org/dc/terms/'
         }
+      end
+
+      it 'renders <dc:title> and <dcterms:title> per the schema mappings' do
+        patch_schema_mappings(
+          'title' => { 'simple_dc_pmh' => 'dc:title', 'qualified_dc_pmh' => 'dcterms:title' }
+        )
+
+        get '/sword/v2/works/work-123', headers: { 'Api-key' => 'test' }
+
+        doc = Nokogiri::XML(response.body)
         expect(doc.root.xpath('dc:title', ns).text).to eq 'Test Work'
         expect(doc.root.xpath('dcterms:title', ns).text).to eq 'Test Work'
+      end
+
+      it 'does not emit dc/dcterms for terms with no mapping' do
+        patch_schema_mappings(
+          'title' => { 'simple_dc_pmh' => 'dc:title', 'qualified_dc_pmh' => 'dcterms:title' }
+        )
+
+        get '/sword/v2/works/work-123', headers: { 'Api-key' => 'test' }
+
+        doc = Nokogiri::XML(response.body)
+        expect(doc.root.xpath('dc:description', ns)).to be_empty
+        expect(doc.root.xpath('dcterms:description', ns)).to be_empty
+        expect(doc.root.xpath('dc:creator', ns)).to be_empty
+        expect(doc.root.xpath('dcterms:creator', ns)).to be_empty
+      end
+
+      it 'emits only the declared namespace when only one of simple/qualified is set' do
+        patch_schema_mappings(
+          'title' => { 'qualified_dc_pmh' => 'dcterms:title' }
+        )
+
+        get '/sword/v2/works/work-123', headers: { 'Api-key' => 'test' }
+
+        doc = Nokogiri::XML(response.body)
+        expect(doc.root.xpath('dcterms:title', ns).text).to eq 'Test Work'
+        expect(doc.root.xpath('dc:title', ns)).to be_empty
       end
     end
   end

--- a/spec/views/willow_sword/works/show.xml+hyku.builder_spec.rb
+++ b/spec/views/willow_sword/works/show.xml+hyku.builder_spec.rb
@@ -83,31 +83,79 @@ RSpec.describe 'willow_sword/works/show.xml+hyku.builder', type: :view do
         <h4cmeta:source>Test source</h4cmeta:source>
         <h4cmeta:subject>Test subject</h4cmeta:subject>
         <h4cmeta:video_embed>https://www.youtube.com/embed/Znf73dsFdC8</h4cmeta:video_embed>
-        <dc:title>Test Title</dc:title>
-        <dcterms:abstract>Test abstract</dcterms:abstract>
-        <dcterms:accessRights>Test access right</dcterms:accessRights>
-        <dcterms:alternative>Test alternative title</dcterms:alternative>
-        <dcterms:bibliographicCitation>Test bibliographic citation</dcterms:bibliographicCitation>
-        <dc:contributor>Test contributor</dc:contributor>
-        <dc:creator>Test creator</dc:creator>
-        <dc:creator>Test creator 2</dc:creator>
-        <dc:date>2020-01-01</dc:date>
-        <dc:description>Test description</dc:description>
-        <dc:identifier>test123</dc:identifier>
-        <dc:publisher>Test publisher</dc:publisher>
-        <dc:language>en</dc:language>
-        <dcterms:license>https://creativecommons.org/licenses/by-nc/4.0/</dcterms:license>
-        <dc:type>Audio</dc:type>
-        <dc:type>Capstone Project</dc:type>
-        <dc:rights>Test rights notes</dc:rights>
-        <dc:rights>http://rightsstatements.org/vocab/NoC-CR/1.0/</dc:rights>
-        <dc:source>Test source</dc:source>
-        <dc:subject>Test subject</dc:subject>
-        <dcterms:modified>2020-01-01T00:00:00+00:00</dcterms:modified>
-        <dcterms:dateSubmitted>2020-01-01T00:00:00+00:00</dcterms:dateSubmitted>
       </feed>
     XML
 
     expect(actual_doc.to_xml).to eq(expected_doc.to_xml)
+  end
+
+  context 'when the schema declares simple_dc_pmh / qualified_dc_pmh mappings' do
+    # Mirrors the canonical mapping set the legacy hardcoded fallback emitted,
+    # exercised end-to-end through the schema-driven path.
+    let(:dc_mappings_by_term) do
+      {
+        'title'                  => { 'simple_dc_pmh' => 'dc:title' },
+        'abstract'               => { 'qualified_dc_pmh' => 'dcterms:abstract' },
+        'access_right'           => { 'qualified_dc_pmh' => 'dcterms:accessRights' },
+        'alternative_title'      => { 'qualified_dc_pmh' => 'dcterms:alternative' },
+        'bibliographic_citation' => { 'qualified_dc_pmh' => 'dcterms:bibliographicCitation' },
+        'contributor'            => { 'simple_dc_pmh' => 'dc:contributor' },
+        'creator'                => { 'simple_dc_pmh' => 'dc:creator' },
+        'date_created'           => { 'simple_dc_pmh' => 'dc:date' },
+        'description'            => { 'simple_dc_pmh' => 'dc:description' },
+        'identifier'             => { 'simple_dc_pmh' => 'dc:identifier' },
+        'publisher'              => { 'simple_dc_pmh' => 'dc:publisher' },
+        'language'               => { 'simple_dc_pmh' => 'dc:language' },
+        'license'                => { 'qualified_dc_pmh' => 'dcterms:license' },
+        'resource_type'          => { 'simple_dc_pmh' => 'dc:type' },
+        'rights_notes'           => { 'simple_dc_pmh' => 'dc:rights' },
+        'rights_statement'       => { 'simple_dc_pmh' => 'dc:rights' },
+        'source'                 => { 'simple_dc_pmh' => 'dc:source' },
+        'subject'                => { 'simple_dc_pmh' => 'dc:subject' },
+        'date_modified'          => { 'qualified_dc_pmh' => 'dcterms:modified' },
+        'date_uploaded'          => { 'qualified_dc_pmh' => 'dcterms:dateSubmitted' }
+      }
+    end
+
+    before do
+      patched_keys = work.class.schema.keys.map do |k|
+        override = dc_mappings_by_term[k.name.to_s]
+        next k unless override
+
+        patched_meta = (k.meta || {}).merge('mappings' => override)
+        Struct.new(:name, :meta).new(k.name, patched_meta)
+      end
+      allow(work.class).to receive(:schema).and_return(double('Schema', keys: patched_keys))
+    end
+
+    it 'renders dc and dcterms tags per the schema mappings' do
+      render template: 'willow_sword/works/show', variants: [:hyku]
+      doc = Nokogiri::XML(rendered)
+      ns = {
+        'atom' => 'http://www.w3.org/2005/Atom',
+        'dc' => 'http://purl.org/dc/elements/1.1/',
+        'dcterms' => 'http://purl.org/dc/terms/'
+      }
+
+      expect(doc.root.xpath('dc:title', ns).text).to eq 'Test Title'
+      expect(doc.root.xpath('dcterms:abstract', ns).text).to eq 'Test abstract'
+      expect(doc.root.xpath('dcterms:accessRights', ns).text).to eq 'Test access right'
+      expect(doc.root.xpath('dcterms:alternative', ns).text).to eq 'Test alternative title'
+      expect(doc.root.xpath('dcterms:bibliographicCitation', ns).text).to eq 'Test bibliographic citation'
+      expect(doc.root.xpath('dc:contributor', ns).text).to eq 'Test contributor'
+      expect(doc.root.xpath('dc:creator', ns).map(&:text)).to eq ['Test creator', 'Test creator 2']
+      expect(doc.root.xpath('dc:date', ns).text).to eq '2020-01-01'
+      expect(doc.root.xpath('dc:description', ns).text).to eq 'Test description'
+      expect(doc.root.xpath('dc:identifier', ns).text).to eq 'test123'
+      expect(doc.root.xpath('dc:publisher', ns).text).to eq 'Test publisher'
+      expect(doc.root.xpath('dc:language', ns).text).to eq 'en'
+      expect(doc.root.xpath('dcterms:license', ns).text).to eq 'https://creativecommons.org/licenses/by-nc/4.0/'
+      expect(doc.root.xpath('dc:type', ns).map(&:text)).to eq ['Audio', 'Capstone Project']
+      expect(doc.root.xpath('dc:rights', ns).map(&:text)).to eq ['Test rights notes', 'http://rightsstatements.org/vocab/NoC-CR/1.0/']
+      expect(doc.root.xpath('dc:source', ns).text).to eq 'Test source'
+      expect(doc.root.xpath('dc:subject', ns).text).to eq 'Test subject'
+      expect(doc.root.xpath('dcterms:modified', ns).text).to eq '2020-01-01T00:00:00+00:00'
+      expect(doc.root.xpath('dcterms:dateSubmitted', ns).text).to eq '2020-01-01T00:00:00+00:00'
+    end
   end
 end


### PR DESCRIPTION
## 🎁 Remove hardcoded terms and rely only on schema

1c68f3696b3d2a59cc0db9e3a1bd55452f564292

This commit will remove the hardcoded terms from the V2 crosswalk and
rely only on the schema to determine the terms for the dc and dcterms
namespaces.

## 🎁 Remove hardcoded terms from legacy crosswalk

bbfeed0af0351ec9b3b62fe41bc8231368253a1a

Now we remove the hardcoded terms from the legacy crosswalk and only
rely on the schema.
