### PR TITLE
⬆️ Bump version to 0.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    willow_sword (0.9.0)
+    willow_sword (0.9.1)
       bagit (>= 0.4)
       rails (>= 6.1)
       rubyzip (>= 1.0.0)

--- a/lib/willow_sword/version.rb
+++ b/lib/willow_sword/version.rb
@@ -1,3 +1,3 @@
 module WillowSword
-  VERSION = '0.9.0'
+  VERSION = '0.9.1'
 end


### PR DESCRIPTION
Ships the deposit-hardening security fixes (command injection, path traversal, and symlink file disclosure) from #73.